### PR TITLE
Install the grads scripts as executables

### DIFF
--- a/GMAO_etc/CMakeLists.txt
+++ b/GMAO_etc/CMakeLists.txt
@@ -132,6 +132,6 @@ set (grads_files
    info.gs
    )
 
-install (FILES ${grads_files}
+install (PROGRAMS ${grads_files}
    DESTINATION lib/grads
    )


### PR DESCRIPTION
Technically, only one (`lats4d`) is an actual script, but they are all
executable in CVS