### PR TITLE
Fixes #35. Fix GMAO_gfio existence check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,6 @@ esma_add_subdirectories(
   GEOS_Shared
   GMAO_hermes
   GEOS_Util 
-  Chem_Base
-  Chem_Shared
   LANL_Shared
   GMAO_perllib
   GMAO_transf
@@ -32,7 +30,7 @@ esma_add_subdirectories(
   )
 
 # Special case - GMAO_gfio is built twice with two different precisions.
-if (EXISTS GMAO_gfio)
+if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GMAO_gfio)
   add_subdirectory (GMAO_gfio GMAO_gfio_r4)
   add_subdirectory (GMAO_gfio GMAO_gfio_r8)
   add_dependencies (GMAO_gfio_r4 GMAO_gfio_r8)


### PR DESCRIPTION
Turns out CMake `EXISTS` requires a full path.

Also, remove Chem_Base and Chem_Shared. They are in a different repo. :smile: