### PR TITLE
Fixes #49. Build stats.x as big-endian

### DIFF
--- a/GEOS_Util/post/CMakeLists.txt
+++ b/GEOS_Util/post/CMakeLists.txt
@@ -32,6 +32,7 @@ ecbuild_add_executable (TARGET stats.x SOURCES stats.F90)
 if (DISABLE_FIELD_WIDTH_WARNING)
   set_target_properties (stats.x PROPERTIES COMPILE_FLAGS ${DISABLE_FIELD_WIDTH_WARNING})
 endif ()
+set_target_properties (stats.x PROPERTIES COMPILE_FLAGS ${BIG_ENDIAN})
 ecbuild_add_executable (TARGET convert_aerosols.x SOURCES convert_aerosols.F)
 
 file(GLOB perlscripts *.pl)


### PR DESCRIPTION
This matches how `stats.F90` was built in CVS. In truth, it might be better to later (after testing) make it work as little-endian