### PR TITLE
Fixes #53. Git fixes for quickstat

### DIFF
--- a/GEOS_Util/plots/CMakeLists.txt
+++ b/GEOS_Util/plots/CMakeLists.txt
@@ -18,7 +18,6 @@ endif ()
 
 set (plots_progs
    quickplot
-   quickstat
    configure
    landscape.script
    portrait.script
@@ -35,6 +34,9 @@ install (
    PROGRAMS ${plots_progs}
    DESTINATION plots
    )
+
+configure_file(quickstat quickstat @ONLY)
+install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/quickstat DESTINATION bin)
 
 # From https://stackoverflow.com/questions/7787823/cmake-how-to-get-the-name-of-all-subdirectories-of-a-directory
 

--- a/GEOS_Util/plots/quickstat
+++ b/GEOS_Util/plots/quickstat
@@ -251,28 +251,9 @@ if( $batch == 'BATCH' ) then
 
 # Set Default GEOS Build Directories
 # ----------------------------------
-                set   command = `which $0`
-set   root =   `echo $command | cut -d / -f1`
-if(  $root == . ) set command = `echo $lcd`/quickstat
-  set root =   `echo $command | cut -b1`
-if( "$root" != "/" ) set command = `echo $lcd`/$command
-
-@ n = 1
-set root = `echo $command | cut -d / -f$n`
-while( .$root == . )
-@ n = $n + 1
-set root = `echo $command | cut -d / -f$n`
-end
-
-set GEOSDEF = ''
-while( $root != 'src' )
-set GEOSDEF = `echo ${GEOSDEF}/${root}`
-@ n = $n + 1
-set root = `echo $command | cut -d / -f$n`
-end
-set  GEOSSRC = ${GEOSDEF}/src
-set  GEOSBIN = ${GEOSDEF}/Linux/bin
-set  GEOSAPP = ${GEOSDEF}/src/Applications/GEOSgcm_App
+set  GEOSSRC = @CMAKE_INSTALL_PREFIX@
+set  GEOSBIN = @CMAKE_INSTALL_PREFIX@/bin
+set  GEOSAPP = @CMAKE_INSTALL_PREFIX@/bin
 
 
 # Create QUICKSTAT commands


### PR DESCRIPTION
Use `configure_file()` to correct set the installation directory in `quickstat`