### PR TITLE
Fixes #88. Intel MPI on SLES 12/SLURM 19 is good

### DIFF
--- a/GMAO_etc/esma_mpirun
+++ b/GMAO_etc/esma_mpirun
@@ -254,9 +254,9 @@ sub get_xtraflags {
     if ($mpi_type eq "intel") {
        if ($perhost) {
 
-          # Detect if we are on slurm
-          # -------------------------
-          if ($ENV{SLURM_JOB_ID}) {
+          # Detect if we are on slurm on SLES 11
+          # ------------------------------------
+          if ($ENV{SLURM_JOB_ID} && ! -e "/etc/os-release") {
 
              #############################################################
              # Intel MPI on SLURM handles -perhost in a possibly         #


### PR DESCRIPTION
`esma_mpirun` does a check if you are running Intel MPI on SLURM and puts in a protection for running with `-perhost`. A test shows this isn't needed with Intel MPI on SLES 12.