### PR TITLE
This update to CICE allows reading binary grid files with both ifort and

### DIFF
--- a/LANL_Shared/LANL_cice/source/ice_read_write.F90
+++ b/LANL_Shared/LANL_cice/source/ice_read_write.F90
@@ -69,6 +69,7 @@
            nbits         ! no. of bits per variable (0 for sequential access)
 
       character (*) :: filename
+      integer       :: recln, i
 !
 !EOP
 !
@@ -79,7 +80,8 @@
             open(nu,file=filename,form='unformatted')
 
          else                   ! direct access
-            open(nu,file=filename,recl=nx_global*ny_global*nbits/8, &
+            inquire(iolength=recln) [(i,i=1,nx_global*ny_global*nbits/8)]
+            open(nu,file=filename,recl=recln, &
                   form='unformatted',access='direct')
          endif                   ! nbits = 0
 


### PR DESCRIPTION
This is part of merges from CVS S2S3 tag into git and includes update to CICE, which allows both ifort and gfortran to read CICE grid file. Previous version has problem with gfortran, since it has different default record length than ifort. @zhaobin74 could you please review this again?