### PR TITLE
Fixes #104. Remove extraneous comma

### DIFF
--- a/GEOS_Shared/lightning_toolbox_mod.F90
+++ b/GEOS_Shared/lightning_toolbox_mod.F90
@@ -197,7 +197,7 @@ CONTAINS
 !$OMP PRIVATE( Z_IC,        LBOTTOM,  HBOTTOM,  CC,     FLASHRATE ) &
 !$OMP PRIVATE( IC_CG_RATIO, RATE                                  ) &
 !$OMP PRIVATE( X,           TOTAL_IC, TOTAL_CG, TOTAL,  REDIST    ) &
-!$OMP PRIVATE( RATE_SAVE,   SFCTYPE,                              ) &
+!$OMP PRIVATE( RATE_SAVE,   SFCTYPE                               ) &
 !$OMP PRIVATE( LTOP1,       LTOP2                                 ) &
 !$OMP SCHEDULE( DYNAMIC )
 


### PR DESCRIPTION
If one compiles `lightning_toolbox_mod.F90` with OpenMP on, it will fail due to an extraneous comma. I don't know if it *works* with OpenMP on (as GEOS doesn't build that way) but it will at least build.