### PR TITLE
Fixes GCC 10 Release Build

### DIFF
--- a/GMAO_hermes/CMakeLists.txt
+++ b/GMAO_hermes/CMakeLists.txt
@@ -3,7 +3,7 @@ esma_set_this()
 add_definitions (-DHERMES -DDEBUG_SHAVE -Dunix -D__unix__)
 string (REPLACE " " ";" flags ${FREAL8})
 add_compile_options(${flags})
-set (CMAKE_Fortran_FLAGS_RELEASE "-O3 ${common_Fortran_flags} ${ALIGNCOM}")
+set (CMAKE_Fortran_FLAGS_RELEASE "-O3 ${common_Fortran_flags} ${ALIGNCOM} ${MISMATCH}")
 
 if ( NOT HERMES_LIGHT )
 

--- a/GMAO_transf/CMakeLists.txt
+++ b/GMAO_transf/CMakeLists.txt
@@ -82,7 +82,7 @@ set (srcs
    gmap.F
    )
 
-set (CMAKE_Fortran_FLAGS_RELEASE "-O3 ${common_Fortran_flags} ${EXTENDED_SOURCE} ${ALIGNCOM}")
+set (CMAKE_Fortran_FLAGS_RELEASE "-O3 ${common_Fortran_flags} ${EXTENDED_SOURCE} ${ALIGNCOM} ${MISMATCH}")
 set (CMAKE_Fortran_FLAGS_DEBUG   "${GEOS_Fortran_FLAGS_DEBUG} ${EXTENDED_SOURCE}")
 
 ecbuild_add_executable(TARGET dyn_divo.x SOURCES dyn_divo.F90 LIBS ${this} FFLAGS "${FREAL8}")


### PR DESCRIPTION
Thanks to @nosolls, there were two places in GMAO_Shared that failed to build with GCC 10 when using Release flags because of idiosyncratic CMake. The solution is to add `${MISMATCH}` to the CMake. Note that on Intel this is a *blank* flag, thus nothing should change make-wise.