### PR TITLE
Use r4i4 ncep_sp in gmao_transf

### DIFF
--- a/GMAO_transf/CMakeLists.txt
+++ b/GMAO_transf/CMakeLists.txt
@@ -9,12 +9,12 @@ add_definitions (-Dopenmp)
 # use r4i4 to get zero-diff with the GNU Make build
 # The "correct" lines should be:
 #
-#include_directories (${include_NCEP_sp_r8i4})
+#include_directories (${include_NCEP_sp_r4i4})
 #include_directories (${include_NCEP_w3_r8i4})
-#esma_add_library (${this} SRCS ${srcs} DEPENDENCIES GMAO_mpeu NCEP_sp_r8i4 NCEP_w3_r8i4 NCEP_sfcio GMAO_hermes NCEP_sigio)
+#esma_add_library (${this} SRCS ${srcs} DEPENDENCIES GMAO_mpeu NCEP_sp_r4i4 NCEP_w3_r8i4 NCEP_sfcio GMAO_hermes NCEP_sigio)
 
 include_directories (${include_GMAO_mpeu})
-include_directories (${include_NCEP_sp_r8i4})
+include_directories (${include_NCEP_sp_r4i4})
 include_directories (${include_NCEP_w3_r8i4})
 include_directories (${include_NCEP_sfcio})
 include_directories (${include_GMAO_hermes})
@@ -96,7 +96,7 @@ install (PROGRAMS ec2fv.csh DESTINATION bin)
 #This needs to be worked on
 ecbuild_add_executable(TARGET ss2gg.x SOURCES ss2gg.f90 LIBS NCEP_w3_r4i4 NCEP_sp_r4i4 NCEP_bacio_r4i4 NCEP_sigio)
 
-esma_add_library(${this} SRCS ${srcs} DEPENDENCIES GMAO_mpeu NCEP_sp_r8i4 NCEP_w3_r8i4 NCEP_sfcio GMAO_hermes NCEP_sigio ${MKL_LIBRARIES})
+esma_add_library(${this} SRCS ${srcs} DEPENDENCIES GMAO_mpeu NCEP_sp_r4i4 NCEP_w3_r8i4 NCEP_sfcio GMAO_hermes NCEP_sigio ${MKL_LIBRARIES})
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
 
 string (REPLACE " " ";" flags ${FREAL8})


### PR DESCRIPTION
Use this r4i4 version of ncesp_sp in gmao_transf. This is needed so that the GEOSgcm.x will link to this version allowing the JCAP functionality to work again in mkiau gridcomp as that needs the r4 version. Note this is non-zero diff if using stochastic phyiscs (SPPT: 1 and SKEP: 1). However, I would be suspicious of any answer from that as if you turn on that option with debugging it fails in the stochastic physics with an out of bounds error. 