### PR TITLE
Edit Open MPI flags

### DIFF
--- a/GMAO_etc/esma_mpirun
+++ b/GMAO_etc/esma_mpirun
@@ -335,8 +335,6 @@ sub get_xtraflags {
           $xtraflags .= " -oversubscribe";
        } elsif ($perhost) {
           $xtraflags .= " -map-by ppr:$perhost:node -bind-to core";
-       } else {
-          $xtraflags .= " -map-by core -bind-to core";
        }
 
     }


### PR DESCRIPTION
For some reason (perhaps because I built Open MPI 4.0.4 incorrectly, though I didn't change anything from my 4.0.3 builds), using:
```
mpirun -bind-to core -map-by core
```
with Open MPI 4.0.4 and Intel 19.1.1 fails. It just crashes. But, since Open MPI isn't a "performance" stack, perhaps defaulting to "just" `mpirun` is a good default, and it seems to work.

Weirdly, the more complex:
```
mpirun -bind-to core -map-by ppr:N:node
```
*does* work. Weird.