### PR TITLE
Feature/san akel/for data lake

### DIFF
--- a/GEOS_Util/pre/NSIDC-OSTIA_SST-ICE_blend/CMakeLists.txt
+++ b/GEOS_Util/pre/NSIDC-OSTIA_SST-ICE_blend/CMakeLists.txt
@@ -37,6 +37,11 @@ ecbuild_add_executable (
   SOURCES proc_SST_FRACI_ostia_quart.F90
   LIBS ${this})
 
+ecbuild_add_executable (
+  TARGET lake_sst_sic_EIGTHdeg.x
+  SOURCES lake_data_EIGTHdeg.F90
+  LIBS ${this})
+
 file(GLOB cshscripts *.csh)
 file(GLOB perlscripts *.pl)
 install(PROGRAMS ${cshscripts} ${perlscripts} DESTINATION bin)

--- a/GEOS_Util/pre/NSIDC-OSTIA_SST-ICE_blend/CMakeLists.txt
+++ b/GEOS_Util/pre/NSIDC-OSTIA_SST-ICE_blend/CMakeLists.txt
@@ -42,6 +42,15 @@ ecbuild_add_executable (
   SOURCES lake_data_EIGTHdeg.F90
   LIBS ${this})
 
+if (F2PY_FOUND)
+   add_f2py_module(read_ops_bcs
+      SOURCES read_bin.f90
+      DESTINATION bin
+      INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${include_${this}}
+      )
+   add_dependencies(read_ops_bcs ${this})
+endif (F2PY_FOUND)
+
 file(GLOB cshscripts *.csh)
 file(GLOB perlscripts *.pl)
 install(PROGRAMS ${cshscripts} ${perlscripts} DESTINATION bin)

--- a/GEOS_Util/pre/NSIDC-OSTIA_SST-ICE_blend/README_lake
+++ b/GEOS_Util/pre/NSIDC-OSTIA_SST-ICE_blend/README_lake
@@ -1,0 +1,4 @@
+proc_singleDay.csh <year> <month> <day> OSTIA 'yes'
+
+example:
+proc_singleDay.csh 2020 3 1 OSTIA 'yes'

--- a/GEOS_Util/pre/NSIDC-OSTIA_SST-ICE_blend/gen_input.csh
+++ b/GEOS_Util/pre/NSIDC-OSTIA_SST-ICE_blend/gen_input.csh
@@ -1,0 +1,85 @@
+#!/bin/csh
+
+set year    = $1
+set month_  = $2
+set today_  = $3
+set whichSST=$4
+
+if ($#argv < 4 ) then
+  echo " "
+  echo " Not all inputs are specified. Exiting!"
+  echo " "
+  exit 1
+endif
+# ---------------------------------------------------------
+
+# run specific settings
+
+# resolution
+set NLAT      = 1440
+set NLON      = 2880
+
+# if NLAT=720, NLON=1440, i.e., MERRA-2 BCs resolution, then iMerra can be set to 1.
+set iMerra          = 0
+
+# make sure we do not have sea ice if SST > SST_Thr (set below).
+set iAdjust_SST_SIC = 1
+set SST_Thr         = 283.15
+# ---------------------------------------------------------
+
+set one       = 1
+set tomorrow_ = `expr ${today_} + $one`
+
+# form the dates
+set month     =                `echo ${month_}    | awk '{printf "%02d", $1}'`
+set today     = ${year}${month}`echo ${today_}    | awk '{printf "%02d", $1}'`
+set tomorrow  = ${year}${month}`echo ${tomorrow_} | awk '{printf "%02d", $1}'`
+# ---------------------------------------------------------
+
+# get foundation SST file to scratch dir
+set scDir = ${PWD}/${whichSST}/
+if (! -e ${scDir}) /bin/mkdir -p ${scDir}
+
+# form source file names and fetch
+if (${whichSST} == 'OSTIA') then
+
+  set ostia_data_loc = '/discover/nobackup/dao_ops/intermediate/flk/stage/ostia/'
+  set ostia_fPref    = ''
+  set ostia_fSuff_   = '-UKMO-L4HRfnd-GLOB-v01-fv02-OSTIA.nc.bz2'
+  set ostia_fSuff    = '-UKMO-L4HRfnd-GLOB-v01-fv02-OSTIA.nc'
+
+  set ostia_file_ops = `/bin/ls ${ostia_data_loc}/${ostia_fPref}${today}${ostia_fSuff_}`
+  set fndSST_file    = ${scDir}/${ostia_fPref}${today}${ostia_fSuff}
+
+  if (! -e ${fndSST_file}) then
+#   /usr/bin/dmget ${ostia_file_ops}
+    /bin/cp ${ostia_file_ops}    ${scDir}
+    /usr/bin/bunzip2 ${scDir}/*.bz2
+  endif
+
+else
+  echo "Unknown option for whichSST:" ${whichSST} ". Exiting"
+  exit 99
+endif
+
+set reynolds_data_loc = '/gpfsm/dnb42/projects/p17/production/GEOS5odas-5.00/RC/OBS/REYN/2020/'
+set reynolds_fPref    = 'oisst-avhrr-v02r01.'
+set reynolds_fSuff    = '.nc'
+#set reynolds_fSuff2  = '_preliminary.nc'
+set reynolds_file     = `/bin/ls ${reynolds_data_loc}/${reynolds_fPref}${today}${reynolds_fSuff}`
+# ---------------------------------------------------------
+
+# generate input for processing
+if (! -e input.txt) then
+  echo ${today}           >input.txt
+  echo ${tomorrow}       >>input.txt
+  echo ${reynolds_file}  >>input.txt
+  echo ${fndSST_file}    >>input.txt
+  echo ${NLAT}           >>input.txt
+  echo ${NLON}           >>input.txt
+  echo ${iMerra}         >>input.txt
+  echo ${iAdjust_SST_SIC}>>input.txt
+  echo ${SST_Thr}        >>input.txt
+else
+  echo "input.txt already exists. Nothing to do. Exiting!"
+endif

--- a/GEOS_Util/pre/NSIDC-OSTIA_SST-ICE_blend/lake_data_EIGTHdeg.F90
+++ b/GEOS_Util/pre/NSIDC-OSTIA_SST-ICE_blend/lake_data_EIGTHdeg.F90
@@ -1,0 +1,235 @@
+!
+PROGRAM lake_data_EIGTHdeg
+!---------------------------------------------------------------------------
+        IMPLICIT NONE
+
+        INTEGER, PARAMETER      :: iDebug                 =  0
+
+        REAL,    PARAMETER      :: myUNDEF                = 1.0e15
+        REAL,    PARAMETER      :: TempLow                = 273.15d0 ! low sst (in deg K) below which there is ice
+        REAL,    PARAMETER      :: Ice_thr                = 1.0e-4   ! threshold on ice concentration- related to TempLow
+
+        INTEGER, PARAMETER      :: reynolds_NLAT          = 720
+        INTEGER, PARAMETER      :: reynolds_NLON          = 1440
+
+        INTEGER, PARAMETER      :: ostia_NLAT             = 3600
+        INTEGER, PARAMETER      :: ostia_NLON             = 7200
+
+        CHARACTER (LEN = 100)   :: inputBuffer, inputFile
+        CHARACTER (LEN = 150)   :: fileNames(2)
+        CHARACTER (LEN = 8)     :: today, tomrw
+
+        CHARACTER (LEN = 150)   :: fileName_Reynolds,  fileName_Ostia
+        CHARACTER (LEN = 40)    :: fileName_ostia_SST, fileName_ostia_ICE
+        CHARACTER (LEN = 40)    :: fileName_mask
+
+        INTEGER                 :: iERR, iMerra
+        INTEGER                 :: NLAT_out
+        INTEGER                 :: NLON_out
+        INTEGER                 :: iLon, iLat
+        INTEGER                 :: iAdjust_SST_SIC
+        REAL                    :: SST_thr                           ! threshold on SST- above which we "expect" no sea-ice 
+
+        REAL                    :: reynolds_LAT        (reynolds_NLAT), reynolds_LON(reynolds_NLON)
+        REAL                    :: reynolds_SST_native (reynolds_NLON,  reynolds_NLAT)
+        REAL                    :: reynolds_ICE_native (reynolds_NLON,  reynolds_NLAT)
+
+        REAL, ALLOCATABLE       :: reynolds_SST_eigth(:,:), reynolds_ICE_eigth(:,:)
+        REAL, ALLOCATABLE       :: ostia_SST_native  (:,:),   ostia_SST_eigth (:,:)
+        REAL, ALLOCATABLE       :: ostia_ICE_native  (:,:),   ostia_ICE_eigth (:,:)
+        REAL, ALLOCATABLE       :: mask(:,:)
+
+        REAL                    :: HEADER(14)
+        CHARACTER(LEN = 4)      :: today_Year, tomrw_Year
+        CHARACTER(LEN = 2)      :: today_Mon,  tomrw_Mon, today_Day, tomrw_Day
+        INTEGER                 :: today_iYear, tomrw_iYear
+        INTEGER                 :: today_iMon,  tomrw_iMon, today_iDay, tomrw_iDay
+!       ....................................................................
+
+!---------------------------------------------------------------------------
+!       Read all input data parameters (time to proc, files to proc, output resolution)
+        CALL getarg(1,inputBuffer)
+        READ(inputBuffer, *) inputFile
+        CALL read_input(inputFile, iDebug, today, tomrw, fileNames, NLAT_out, NLON_out, iMerra, iAdjust_SST_SIC, SST_Thr, iERR)
+!---------------------------------------------------------------------------
+        IF( iERR == 0) THEN
+             PRINT *, 'Data over Great Lakes and Caspian Sea'
+             PRINT *, 'Processing SST and ICE data from: ', today, '...To... ', tomrw
+        ELSE
+             PRINT *, 'User input is not in correct format- for this program to work!'
+             PRINT *, 'SEE ABOVE LOG FOR DETAILS'
+             STOP
+        END IF
+
+        fileName_Reynolds = fileNames(1)
+        fileName_Ostia    = fileNames(2)
+!------------------------------Read input files----------------------------
+!       Read Reynolds 
+!       SST               -> reynolds_SST_native 
+!       Ice concentration -> reynolds_ICE_native
+        CALL read_Reynolds(fileName_Reynolds, reynolds_NLAT, reynolds_NLON,                        &
+                           reynolds_LAT, reynolds_LON,                                             &
+                           reynolds_SST_native, reynolds_ICE_native, myUNDEF)
+
+!       Read Ostia 
+!       SST               -> ostia_SST_native
+!       Ice concentration -> ostia_ICE_native
+        ALLOCATE( ostia_SST_native(ostia_NLON, ostia_NLAT) )
+        ALLOCATE( ostia_ICE_native(ostia_NLON, ostia_NLAT) )
+        CALL read_Ostia( fileName_Ostia, "analysed_sst",     ostia_NLAT, ostia_NLON, ostia_SST_native, myUNDEF )
+        CALL read_Ostia( fileName_Ostia, "sea_ice_fraction", ostia_NLAT, ostia_NLON, ostia_ICE_native, myUNDEF )
+
+!------------------------------Process SST & ICE fields--------------------
+!       reynolds ice has undef in open water as well. make that to 0.
+        WHERE( (reynolds_SST_native .ne. myUNDEF) .and. (reynolds_ICE_native == myUNDEF))
+             reynolds_ICE_native = 0.0d0
+        END WHERE
+
+!       Reynolds(SST, ICE): (1) flip, (2) interp to 1/8 deg
+        ALLOCATE( reynolds_SST_eigth(NLON_out,      NLAT_out     ))
+        ALLOCATE( reynolds_ICE_eigth(NLON_out,      NLAT_out     ))
+
+        CALL hflip              ( reynolds_SST_native, reynolds_NLON, reynolds_NLAT )
+        CALL hflip              ( reynolds_ICE_native, reynolds_NLON, reynolds_NLAT )
+
+        CALL interp_to_eight_deg( reynolds_SST_native, reynolds_NLON, reynolds_NLAT,                &
+                                  reynolds_SST_eigth, NLON_out, NLAT_out, myUNDEF)
+        CALL interp_to_eight_deg( reynolds_ICE_native, reynolds_NLON, reynolds_NLAT,                &
+                                  reynolds_ICE_eigth, NLON_out, NLAT_out, myUNDEF)
+
+!---------------------------------------------------------------------------
+        ALLOCATE( ostia_SST_eigth(NLON_out,  NLAT_out ))
+        ALLOCATE( ostia_ICE_eigth(NLON_out,  NLAT_out ))
+        ALLOCATE( mask            (NLON_out,  NLAT_out ))
+
+!       Initialize
+        mask = 0.
+
+!       Ostia(SST, ICE): bin to 1/8 deg.
+        CALL bin2bin( ostia_SST_native, ostia_NLON, ostia_NLAT, ostia_SST_eigth, NLON_out, NLAT_out, myUNDEF )
+        CALL bin2bin( ostia_ICE_native, ostia_NLON, ostia_NLAT, ostia_ICE_eigth, NLON_out, NLAT_out, myUNDEF )
+!---------------------------------------------------------------------------
+!       Get Great Lakes SST and ICE from Reynolds into OSTIA (if needed)
+        DO iLat = 1046, 1120
+         DO iLon = 695, 842
+
+            mask(iLon,iLat) = 1.0
+
+            IF( (ostia_SST_eigth(iLon,iLat).eq.myUNDEF) .and. (reynolds_SST_eigth(iLon,iLat).ne.myUNDEF) ) THEN
+                 ostia_SST_eigth(iLon,iLat) = reynolds_SST_eigth(iLon,iLat)
+            END IF
+
+            IF( (ostia_ICE_eigth(iLon,iLat).eq.myUNDEF) .and. (reynolds_ICE_eigth(iLon,iLat).ne.myUNDEF) ) THEN
+                 ostia_ICE_eigth(iLon,iLat) = reynolds_ICE_eigth(iLon,iLat)    ! if OSTIA had no ice in Great Lakes, get data from Reynolds
+            END IF
+         END DO
+        END DO
+!---------------------------------------------------------------------------
+!       Caspian Sea ice: there is no ice info in OSTIA ICE, when temp < freezing point, fix this problem.
+        DO iLat = 1000, 1120
+         DO iLon = 1800, 1890
+
+            mask(iLon,iLat) = 1.0
+
+            ! 1st. handle SST. if OSTIA SST = undef, then use Reynolds SST
+            IF( (ostia_SST_eigth(iLon,iLat).eq.myUNDEF) .and. (reynolds_SST_eigth(iLon,iLat).ne.myUNDEF) ) THEN
+                 ostia_SST_eigth(iLon,iLat) = reynolds_SST_eigth(iLon,iLat)
+            END IF
+
+            ! if sst < freezing temp
+            IF( ostia_SST_eigth(iLon,iLat) <= 275.0d0) THEN
+              ! if there is no ice data or ice ~ 0.0 
+              IF( (ostia_ICE_eigth(iLon,iLat) .eq. myUNDEF) .or. (ostia_ICE_eigth(iLon,iLat) <= Ice_thr)) THEN
+                  IF( (reynolds_ICE_eigth(iLon,iLat) .ne. myUNDEF) .and. (reynolds_ICE_eigth(iLon,iLat) > Ice_thr)) THEN
+                     ostia_ICE_eigth(iLon,iLat)  = reynolds_ICE_eigth(iLon,iLat)                         ! use Reynolds ice
+                  ELSE                                                                                   ! there is nothing useful from Reynolds, use empirical fit
+                     ! this could be computed based on SST from OSTIA/Reynolds.
+                     ostia_ICE_eigth(iLon,iLat)  = MIN( 1.0d0, MAX(-0.017451*((ostia_SST_eigth(iLon,iLat)- 271.38)/0.052747) + 0.96834, 0.0d0))
+                  END IF
+              END IF
+            END IF  ! IF( ostia_SST_eigth(iLon,iLat) <= 275.0d0)
+         END DO
+        END DO
+!---------------------------------------------------------------------------
+        
+        IF ( iAdjust_SST_SIC == 1) THEN
+!          adjust SIC based on a threshold value of SST
+           WHERE (ostia_SST_eigth > SST_Thr)
+               ostia_ICE_eigth = 0.0d0
+           END WHERE
+        END IF
+!---------------------------------------------------------------------------
+
+!       get rid of the masked values
+        WHERE( (ostia_SST_eigth <= 260.) .or. (ostia_SST_eigth >= 330.))
+               ostia_SST_eigth = -999.
+        ENDWHERE
+
+        WHERE (ostia_SST_eigth == -999.)
+               ostia_ICE_eigth = -999.
+        ENDWHERE
+
+        WHERE( (ostia_ICE_eigth < 0.0) .or. (ostia_ICE_eigth > 1.0))
+               ostia_ICE_eigth = -999.
+        ENDWHERE
+!---------------------------------------------------------------------------
+
+!       Header info.  Start & end dates: format: YYYYMMDDHHMMSS; Hour,min,Sec are set to zero.
+        today_Year    = today(1:4);      tomrw_Year    = tomrw(1:4)
+        today_Mon     = today(5:6);      tomrw_Mon     = tomrw(5:6)
+        today_Day     = today(7:8);      tomrw_Day     = tomrw(7:8)
+
+        READ( today_Year, 98) today_iYear
+        READ( tomrw_Year, 98) tomrw_iYear
+
+        READ( today_Mon,  99) today_iMon
+        READ( tomrw_Mon,  99) tomrw_iMon
+
+        READ( today_Day,  99) today_iDay
+        READ( tomrw_Day,  99) tomrw_iDay
+
+        HEADER(1)    = REAL(today_iYear); HEADER(7)     = REAL(tomrw_iYear)
+        HEADER(2)    = REAL(today_iMon);  HEADER(8)     = REAL(tomrw_iMon)
+        HEADER(3)    = REAL(today_iDay);  HEADER(9)     = REAL(tomrw_iDay)
+        HEADER(4:6)  = 0.0;               HEADER(10:12) = 0.0
+
+        HEADER(13)   = REAL(NLON_out);    HEADER(14)    = REAL(NLAT_out)
+!---------------------------------------------------------------------------
+!       Write out for OSTIA fields for FP & RPIT
+!       SST, ICE:
+        fileName_ostia_SST = 'Ostia_sst_'        // today //'.bin'
+        fileName_ostia_ICE = 'Ostia_ice_'        // today //'.bin'
+        fileName_mask      = 'mask'                       //'.bin'
+
+        OPEN (UNIT = 991, FILE = fileName_ostia_SST, FORM = 'unformatted', STATUS = 'new')
+        OPEN (UNIT = 992, FILE = fileName_ostia_ICE, FORM = 'unformatted', STATUS = 'new')
+        OPEN (UNIT = 993, FILE = fileName_mask,      FORM = 'unformatted', STATUS = 'new')
+
+        WRITE(991) HEADER
+        WRITE(992) HEADER
+        WRITE(993) HEADER
+        WRITE(991) ostia_SST_eigth
+        WRITE(992) ostia_ICE_eigth
+        WRITE(993) mask
+        CLOSE(991)
+        CLOSE(992)
+        CLOSE(993)
+!---------------------------------------------------------------------------
+        IF( iERR == 0) PRINT *, '...Finished!'
+!---------------------------------------------------------------------------
+ 98     FORMAT(I4)
+ 99     FORMAT(I4)
+!---------------------------------------------------------------------------
+        DEALLOCATE(reynolds_SST_eigth)
+        DEALLOCATE(reynolds_ICE_eigth)
+
+        DEALLOCATE(ostia_SST_native)
+        DEALLOCATE(ostia_ICE_native)
+
+        DEALLOCATE(mask)
+
+        DEALLOCATE(ostia_ICE_eigth)
+        DEALLOCATE(ostia_SST_eigth)
+!---------------------------------------------------------------------------
+END PROGRAM lake_data_EIGTHdeg
+!

--- a/GEOS_Util/pre/NSIDC-OSTIA_SST-ICE_blend/plot_bcs.py
+++ b/GEOS_Util/pre/NSIDC-OSTIA_SST-ICE_blend/plot_bcs.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+
+'''
+to plot the SST and SIC boundary conditions (binary files) that are used by the GCM
+
+SA, Jul 2018, Aug 2020
+'''
+#-----------------------------------------------------------------
+
+import  argparse
+
+import  numpy                as      np
+import  matplotlib.pyplot    as      plt
+
+from    datetime             import datetime
+
+import cartopy.crs as ccrs
+import cartopy.feature as cfeature
+
+# read a binary file, uses f2py, see file for compile instructions... change as you may please!
+from    read_ops_bcs         import read_bin_data
+#-----------------------------------------------------------------
+
+def file_names(data_path_, fndSST, date_in):
+
+	data_path = data_path_+ fndSST + '/'
+
+	sst_file_ = data_path + 'Ostia_sst_' + date_in.strftime('%Y%m%d') + '.bin'
+	sic_file_ = data_path + 'Ostia_ice_' + date_in.strftime('%Y%m%d') + '.bin'
+	mask_file_= data_path + 'mask'                                    + '.bin'
+
+	return sst_file_, sic_file_, mask_file_
+#-----------------------------------------------------------------
+
+def main():
+
+   comm_args       = parse_args()
+
+   data_path       = comm_args['data_path']
+
+   year_           = comm_args['year']
+   month_          = comm_args['month']
+   day_            = comm_args['day']
+   whichFndSST     = comm_args['fndSST']
+
+   date_ = datetime( year_, month_, day_, 00, 0, 0)	
+   [sst_file, sic_file, mask_file] = file_names( data_path, whichFndSST, date_)
+
+	# read the OPS SST & SIC. Both are of dimension(1440, 2880); see read_ops_bcs.pyf
+   [date_ofSST, nlon, nlat, lon, lat, sst_] = read_bin_data(sst_file, date_.strftime('%Y%m%d')) # SST  is in K
+   [date_ofSIC, nlon, nlat, lon, lat, sic_] = read_bin_data(sic_file, date_.strftime('%Y%m%d')) # SIC  is non-dimensional
+   [date_ofMask,nlon, nlat, lon, lat, mask_]= read_bin_data(mask_file,date_.strftime('%Y%m%d')) # MASK is non-dimensional
+
+   sst_[sst_ == -999.] = np.nan
+   sic_[sic_ == -999.] = np.nan
+   #-----------------------------------------------------------------
+
+   print('Plotting for [%s] using\n[%s]\n[%s]'%(date_.strftime('%Y%m%d'), sst_file, sic_file))
+	
+	# Plot
+   fig = plt.figure(figsize=(10,6))
+
+	# plot sst
+   ax1 = plt.subplot(221, projection=ccrs.PlateCarree())
+#  ax1 = plt.subplot(221, projection=ccrs.PlateCarree( central_longitude=180))
+
+#  ax1.set_global()
+   ax1.coastlines()
+#  ax1.stock_img()
+   ax1.add_feature(cfeature.LAND,  facecolor='white')
+#  ax1.add_feature(cfeature.LAKES, edgecolor='gray')
+
+   im1 = ax1.pcolormesh(lon, lat, sst_, transform=ccrs.PlateCarree(),\
+         cmap=plt.cm.jet)#, vmin=270., vmax=310.)
+
+   plt.colorbar(im1, pad=0.01, shrink=0.75)
+   plt.title(r'SST (deg K) for %s'%(date_.strftime('%Y%m%d')))
+   plt.axis('off')
+
+	# plot sic
+   ax2 = plt.subplot(222, projection=ccrs.PlateCarree())
+#  ax2.set_global()
+   ax2.coastlines()
+   ax2.add_feature(cfeature.LAND,  facecolor='white')
+#  ax2.add_feature(cfeature.LAKES, edgecolor='gray')
+
+   im2 = ax2.pcolormesh(lon, lat, sic_, transform=ccrs.PlateCarree(),\
+         cmap=plt.cm.jet)#, vmin=0.0, vmax=1.0)
+
+   plt.colorbar(im2, pad=0.01, shrink=0.75)
+   plt.title(r'SIC for %s'%(date_.strftime('%Y%m%d')))
+   plt.axis('off')
+#  -----------------------------------------------------------------
+
+#  plot mask
+   ax3 = plt.subplot(223, projection=ccrs.PlateCarree())
+#  ax3.set_extent([-180, 180, 20, 55], ccrs.PlateCarree())
+   ax3.coastlines()
+   ax3.add_feature(cfeature.LAND,  facecolor='white')
+   ax3.add_feature(cfeature.LAKES, edgecolor='gray')
+
+   im3 = ax3.pcolormesh(lon, lat, mask_, transform=ccrs.PlateCarree(),\
+         cmap=plt.cm.jet)#, vmin=280., vmax=310.)
+
+   plt.colorbar(im3, pad=0.01, shrink=0.75)
+   plt.title(r'Mask (=0 or 1, latter over Great Lakes and Caspian Sea')
+   plt.axis('off')
+#  -----------------------------------------------------------------
+
+   ax4 = plt.subplot(224, projection=ccrs.PlateCarree())
+   ax4.set_extent([-180, 180, 10, 60], ccrs.PlateCarree())
+   ax4.coastlines()
+   ax4.add_feature(cfeature.LAND,  facecolor='white')
+   ax4.add_feature(cfeature.LAKES, edgecolor='gray')
+
+   im4 = ax4.pcolormesh(lon, lat, mask_, transform=ccrs.PlateCarree(),\
+         cmap=plt.cm.jet)#, vmin=280., vmax=310.)
+
+   plt.colorbar(im4, pad=0.01, shrink=0.75)
+   plt.title(r' Zoom in mask')
+   plt.axis('off')
+
+#-----------------------------------------------------------------
+   fName_fig = whichFndSST + '_bcs_SST_SIC_%s'%(date_.strftime('%Y%m%d'))
+   plt.savefig(fName_fig + '.png', dpi=120)	
+   plt.close('all')
+#-----------------------------------------------------------------
+
+def parse_args():
+   p = argparse.ArgumentParser(description = \
+       'Script to plot the SST and sea ice concentration used as lower boundary conditions by the GCM')
+
+   p.add_argument('-data_path',   type=str, help= 'path to the data',  default='/discover/nobackup/sakella/lake_mask/')
+
+   p.add_argument('-year',   type=int, help= 'year',  default=2006)
+   p.add_argument('-month',  type=int, help= 'month', default=4)
+   p.add_argument('-day',    type=int, help= 'day',   default=1)
+   p.add_argument('-fndSST', type=str, help= 'which foundation (e.g., OSTIA1, OSTIA2)', default='OSTIA1')
+
+   return vars(p.parse_args())
+#-----------------------------------------------------------------
+
+if __name__ == '__main__':
+
+        main()
+#-----------------------------------------------------------------

--- a/GEOS_Util/pre/NSIDC-OSTIA_SST-ICE_blend/proc_singleDay.csh
+++ b/GEOS_Util/pre/NSIDC-OSTIA_SST-ICE_blend/proc_singleDay.csh
@@ -1,0 +1,41 @@
+#!/bin/csh
+
+set year      = $1
+set month     = $2
+set day       = $3
+set whichSST=$4
+set toPlot    = $5
+
+set build_dir = /discover/nobackup/sakella/geosMom6/develop_24Jul2020/GEOSgcm/build-Debug/bin/
+# ---------------------------------------------------------
+
+# generate input 
+if ( -e input.txt) /bin/rm -f input.txt
+gen_input.csh ${year} ${month} ${day} ${whichSST}
+
+# generate SST and SIC files
+${build_dir}/lake_sst_sic_EIGTHdeg.x input.txt
+
+# clean up
+/bin/rm -f  ${PWD}/${whichSST}/*.nc
+if (${whichSST} == 'OSTIA') then
+  /bin/mv    Ostia_*.bin ${PWD}/${whichSST}/
+  /bin/mv    mask*.bin   ${PWD}/${whichSST}/
+else
+ echo "Unknown option for whichSST:" ${whichSST} ". Exiting"
+ exit 1
+endif
+
+# plot if needed
+if (${toPlot} == 'yes') then
+  plot_bcs.py -year ${year} -month ${month} -day ${day} -fndSST ${whichSST}
+  /bin/mv *.png ${PWD}/${whichSST}/
+endif
+# ---------------------------------------------------------
+
+# example usage:
+# -------------
+# proc_singleDay.csh 2020 3 1 OSTIA 'yes'  <-- after 03/01 is okay, file with prefix exist: 'oisst-avhrr-v02r01.'
+# proc_singleDay.csh 2020 7 1 OSTIA 'yes'
+
+# gen_input.csh      2020 7 1 OSTIA

--- a/GEOS_Util/pre/NSIDC-OSTIA_SST-ICE_blend/read_bin.f90
+++ b/GEOS_Util/pre/NSIDC-OSTIA_SST-ICE_blend/read_bin.f90
@@ -1,0 +1,96 @@
+!
+! to create a python usable module:
+! f2py -c -m <module_name> <file_name>.f90--->	f2py -c -m read_ops_bcs read_bin.f90
+! to create a signature file:
+! f2py -h <module_name>.pyf <file_name>.f90-->  f2py -h read_ops_bcs.pyf read_bin.f90
+! .....................................................................
+   SUBROUTINE read_bin_data( fileName, nymd_in, nymd_out, NLON, NLAT, LON, LAT, bcs_field)
+
+   IMPLICIT NONE
+
+   CHARACTER (LEN = 200), INTENT(IN)  :: fileName
+   INTEGER,               INTENT(IN)  :: nymd_in
+
+   INTEGER,               INTENT(OUT) :: nymd_out
+   INTEGER,               INTENT(OUT) :: NLON
+   INTEGER,               INTENT(OUT) :: NLAT
+
+   REAL,                  INTENT(OUT) :: LON(2880)
+   REAL,                  INTENT(OUT) :: LAT(1440)
+   REAL,                  INTENT(OUT) :: bcs_field(1440, 2880)
+
+! LOCAL VARS
+   real    year1,month1,day1,hour1,min1,sec1
+   real    year2,month2,day2,hour2,min2,sec2
+   real    dum1,dum2
+   real    dLat,dLon
+   real    field(2880,1440)
+
+   integer nymd1,nhms1
+   integer nymd2,nhms2
+   
+   integer rc, ix
+!  ....................................................................
+
+!     print *, 'nymd_in=', nymd_in
+
+      open (10,file=fileName,form='unformatted',access='sequential', STATUS = 'old')
+!     ....................................................................
+      rc = 0
+      do while (rc.eq.0)
+         ! read header
+         read (10,iostat=rc)  year1,month1,day1,hour1,min1,sec1,                            &
+                              year2,month2,day2,hour2,min2,sec2,dum1,dum2
+         if( rc.eq.0 ) then
+           read (10,iostat=rc)  field
+
+           NLON  = nint(dum1)
+           NLAT  = nint(dum2)
+           IF( (NLON /= 2880) .or. (NLAT /= 1440)) THEN
+              PRINT *, 'ERROR in LAT/LON dimension in file: ', fileName, 'NLON=', NLON, 'NLAT=', NLAT
+              EXIT
+           END IF
+           dLat = 180./NLAT
+           dLon = 360./NLON
+
+           ! start date
+           nymd1 = nint( year1*10000 )  + nint (month1*100)  +  nint( day1 )
+           nhms1 = nint( hour1*10000 )  + nint (  min1*100)  +  nint( sec1 )
+
+           ! end date
+           nymd2 = nint( year2*10000 )  + nint (month2*100)  +  nint( day2 )
+           nhms2 = nint( hour2*10000 )  + nint (  min2*100)  +  nint( sec2 )
+         end if
+
+         if (nymd1 .eq. nymd_in) then
+            nymd_out = nymd1
+
+!           print *, 'nymd_out=', nymd_out
+!!          print *, bcs_field
+
+            LAT(1) = -90. + dLat/2.
+            DO ix = 2, NLAT
+              LAT(ix) = LAT(ix-1) + dLat
+            END DO
+
+            LON(1) = -180. + dLon/2.
+            DO ix = 2, NLON
+              LON(ix) = LON(ix-1) + dLon
+            END DO
+
+            bcs_field = TRANSPOSE(field)
+            close(10)
+            RETURN 
+         end if
+      end do 
+!     ....................................................................
+      close(10)
+
+!     print *, year1,month1,day1,hour1,min1,sec1 
+!     print *, year2,month2,day2,hour2,min2,sec2,dum1,dum2
+!     print *, 'rc = ', rc             
+!---------------------------------------------------------------------------
+    END SUBROUTINE read_bin_data
+! .....................................................................
+!
+


### PR DESCRIPTION
This PR adds code to generate:
1. A mask (=0. or 1.), its value =1 over **Great Lakes and Caspian Sea**. 
2. SST and Ice concentration for any day from either OSTIA SST (binned from its native 1/20 deg to 1/8deg; see below for grid information). If OSTIA SST has no data, we extract from Reynolds SST (and Ice conc) after converting it from its native 1/4 deg to 1/8. All of the grid conversions and extraction of data from Reynolds (if needed) is same as what is currently done for processing SST and Ice Conc data in proc_SST_FRACI.F90

**Note:** The grid is global lat/lon, dlat = dlon = 1/8 deg; dateline edge, pole edge, i.e., starting lat = -90 +  dlat/2, similarly for starting lon. 

In addition it adds:
- Scripts to generate the data (gen_input.csh, proc_singleDay.csh); see README_lake 
file for instructions
- Scripts to plot: plot_bcs.py and read_bin.f90 (which provides a python interface to read the binary data via f2py)


