### PR TITLE
Assume Open MPI as a default mpi stack

### DIFF
--- a/GMAO_etc/esma_mpirun
+++ b/GMAO_etc/esma_mpirun
@@ -37,6 +37,7 @@
 #                       which is not something to be set in esma_mpirun. But
 #                       a fat comment is added for future reference.
 # 03Oct2018  Thompson   Add support for HPC-X and treat as Open MPI
+# 20Aug2020  Thompson   Assume Open MPI to start (for CI, etc.)
 #============================================================================
 use strict;
 use warnings;
@@ -87,7 +88,10 @@ sub init {
 sub get_mpi_type {
     my ($MPIHOME);
 
-    $mpi_type = "unknown";
+    # Assume that the MPI stack will be openmpi (useful for CI, AWS, etc.)
+    # This will be overridden below if a match occurs, but if not, this
+    # will assume openmpi
+    $mpi_type = "openmpi";
 
     # At NCCS, Open MPI modules can define M_MPI_ROOT, so we cannot
     # depend on that as always good. Instead, we'll use the specific


### PR DESCRIPTION
On CI systems, AWS, and other non-NASA or GMAO-maintained systems, the usual MPI stack is Open MPI. `esma_mpirun` will fail if it doesn't find any of the environmental variables that are often set on NCCS/NASA/GMAO machines through modulefiles.

To that end, set the default `mpi_type` to `openmpi` so it will at least default to that if nothing is found. 