### PR TITLE
Update GEOS_Utilities to match ADAS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update `GEOS_Utilities.F90` to match `GEOSadas-5_27_0` (#115)
+
 ### Fixed
 
 ### Removed

--- a/GEOS_Shared/GEOS_Utilities.F90
+++ b/GEOS_Shared/GEOS_Utilities.F90
@@ -535,7 +535,7 @@
        end if
 
        TI = (TI - TMINTBL)*DEGSUBS+1
-       IT = int(TI)
+       IT = nint(TI)
 
        if(URAMP==TMIX) then
           DQ    = ESTBLX(IT+1) - ESTBLX(IT)
@@ -724,7 +724,7 @@
          end if
 
          TT = (TI - TMINTBL)*DEGSUBS+1
-         IT = int(TT)
+         IT = nint(TT)
 
          if(URAMP==TMIX) then
             DQQ =  ESTBLX(IT+1) - ESTBLX(IT)


### PR DESCRIPTION
The `GEOSadas-5_27_0` version of this file has slightly different code, `nint()` instead of `int()`. This brings us inline. 

Marking as non-zero-diff as it might be.