### PR TITLE
Move back to using int() not nint(): Bug in Table Evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 ### Fixed
-
-- Undo the change to `GEOS_Utilities.F90` in v1.2.0. This has a bug at the end of the table (#123)
-
 ### Removed
 ### Added
+
+## [1.3.0] - 2020-09-28
+
+### Fixed
+
+- Undo the change to `GEOS_Utilities.F90` in v1.2.0. This has a bug at the end of the table (#123)
 
 ## [1.2.0] - 2020-09-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 ### Fixed
+
+- Undo the change to `GEOS_Utilities.F90` in v1.2.0. This has a bug at the end of the table (#123)
+
 ### Removed
 ### Added
 

--- a/GEOS_Shared/GEOS_Utilities.F90
+++ b/GEOS_Shared/GEOS_Utilities.F90
@@ -535,7 +535,7 @@
        end if
 
        TI = (TI - TMINTBL)*DEGSUBS+1
-       IT = nint(TI)
+       IT = int(TI)
 
        if(URAMP==TMIX) then
           DQ    = ESTBLX(IT+1) - ESTBLX(IT)
@@ -724,7 +724,7 @@
          end if
 
          TT = (TI - TMINTBL)*DEGSUBS+1
-         IT = nint(TT)
+         IT = int(TT)
 
          if(URAMP==TMIX) then
             DQQ =  ESTBLX(IT+1) - ESTBLX(IT)


### PR DESCRIPTION
Using `nint()` instead of `int()` in `GEOS_Utilities.F90` can cause crashes if Debugging flags are on. To wit we look at this code:
```fortran
      real,    parameter :: TMINTBL    =  150.0
      real,    parameter :: TMAXTBL    =  333.0
      integer, parameter :: DEGSUBS    =  100
...
      integer, parameter :: TABLESIZE  =  nint(TMAXTBL-TMINTBL)*DEGSUBS + 1
...
      real,    save      :: ESTBLX(TABLESIZE)
```
`TABLESIZE` evaluates to (333-150)*100+1 = 18301
Now we look at
```fortran
       if    (TL<=TMINTBL) then
          TI = TMINTBL
       elseif(TL>=TMAXTBL-.001) then
          TI = TMAXTBL-.001
       else
          TI = TL
       end if

       TI = (TI - TMINTBL)*DEGSUBS+1
       IT = nint(TI)

       if(URAMP==TMIX) then
          DQ    = ESTBLX(IT+1) - ESTBLX(IT)
          QSAT  = (TI-IT)*DQ + ESTBLX(IT)
       else
          DQ    = ESTBLE(IT+1) - ESTBLE(IT)
          QSAT  = (TI-IT)*DQ + ESTBLE(IT)
       endif
```
So let's say `TL` comes in larger than `TMAXTBL` at 400. Now we evaluate:
```fortran
TL (= 400) >= TMAXTBL-0.001 (333.0-0.001) ->
TI = TMAXTBL-0.001 ->
TI = 332.999
```
then
```fortran
TI = (TI - TMINTBL)*DEGSUBS+1
TI = (332.999 - 150.0) * 100 + 1
TI = 182.999 * 100 + 1
TI = 18299.9 + 1
TI = 18300.9
```
Then:
```fortran
TI = nint(TI)
TI = 18301
```
Finally:
```fortran
DQ    = ESTBLX(IT+1) - ESTBLX(IT)
```
means we are looking at `ESTBLX(18302)` but `ESTBLX` has an upper bound of 18301 and the model crashes.
