### PR TITLE
Update changelog-enforcer.yml

### DIFF
--- a/.github/workflows/changelog-enforcer.yml
+++ b/.github/workflows/changelog-enforcer.yml
@@ -8,9 +8,8 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: dangoslen/changelog-enforcer@v1.2.0
+    - uses: actions/checkout@v2
+    - uses: dangoslen/changelog-enforcer@v1.4.0
       with:
         changeLogPath: 'CHANGELOG.md'
-        skipLabel: '0 diff trivial'
-
+        skipLabel: 'Skip Changelog'


### PR DESCRIPTION
This PR updates the Changelog Enforcer to use the latest version (1.4.0) along with `actions/checkout@v2`

Also, skipping changelog is triggered by the "Skip Changelog" label (which should only be used in rare circumstances).