### PR TITLE
Add logger for NaN detection in QSAT calls

### DIFF
--- a/GEOS_Shared/GEOS_Utilities.F90
+++ b/GEOS_Shared/GEOS_Utilities.F90
@@ -153,6 +153,7 @@
       real, save :: TMINICE    =  ZEROC + TMINSTR
 
       class(Logger), pointer :: lgr
+      logical :: debugIsEnabled
 
   contains
 
@@ -507,8 +508,10 @@
     real    :: URAMP, DD, QQ, TI, DQ, PP
     integer :: IT
 
-    if (ieee_is_nan(TL)) call lgr%warning(' QSAT0: TL contains NaN')
-    if (ieee_is_nan(PL)) call lgr%warning(' QSAT0: PL contains NaN')
+    if (debugIsEnabled) then
+      if (ieee_is_nan(TL)) call lgr%warning(' QSAT0: TL contains NaN')
+      if (ieee_is_nan(PL)) call lgr%warning(' QSAT0: PL contains NaN')
+    end if
 
     if(present(RAMP)) then
        URAMP = -abs(RAMP)
@@ -526,11 +529,12 @@
        PP = PL*100.
     end if
 
-    if(URAMP==TMIX .OR. URAMP==0. .and. UTBL) then
+    if((URAMP==TMIX .OR. URAMP==0.) .and. UTBL) then
 
        if(FIRST) then
           FIRST = .false.
           call ESINIT
+          call LOGGER_INIT
        end if
 
        if    (TL<=TMINTBL) then
@@ -565,6 +569,11 @@
 
     else
 
+       if(FIRST) then
+          FIRST = .false.
+          call LOGGER_INIT
+       end if
+
        TI = TL - ZEROC
 
        if    (TI <= URAMP) then
@@ -591,8 +600,10 @@
       real :: QSAT(size(TL,1))
       integer :: I
 
-      if (any(ieee_is_nan(TL))) call lgr%warning(' QSAT1: TL contains NaN')
-      if (any(ieee_is_nan(PL))) call lgr%warning(' QSAT1: PL contains NaN')
+      if (debugIsEnabled) then
+         if (any(ieee_is_nan(TL))) call lgr%warning(' QSAT1: TL contains NaN')
+         if (any(ieee_is_nan(PL))) call lgr%warning(' QSAT1: PL contains NaN')
+      end if
 
       do I=1,SIZE(TL,1)
          if (present(DQSAT)) then
@@ -611,8 +622,10 @@
       real :: QSAT(size(TL,1),size(TL,2))
       integer :: I, J
 
-      if (any(ieee_is_nan(TL))) call lgr%warning(' QSAT2: TL contains NaN')
-      if (any(ieee_is_nan(PL))) call lgr%warning(' QSAT2: PL contains NaN')
+      if (debugIsEnabled) then
+         if (any(ieee_is_nan(TL))) call lgr%warning(' QSAT2: TL contains NaN')
+         if (any(ieee_is_nan(PL))) call lgr%warning(' QSAT2: PL contains NaN')
+      end if
 
       do J=1,SIZE(TL,2)
          do I=1,SIZE(TL,1)
@@ -633,8 +646,10 @@
       real :: QSAT(size(TL,1),size(TL,2),size(TL,3))
       integer :: I, J, K
 
-      if (any(ieee_is_nan(TL))) call lgr%warning(' QSAT3: TL contains NaN')
-      if (any(ieee_is_nan(PL))) call lgr%warning(' QSAT3: PL contains NaN')
+      if (debugIsEnabled) then
+         if (any(ieee_is_nan(TL))) call lgr%warning(' QSAT3: TL contains NaN')
+         if (any(ieee_is_nan(PL))) call lgr%warning(' QSAT3: PL contains NaN')
+      end if
 
       do K=1,SIZE(TL,3)
          do J=1,SIZE(TL,2)
@@ -711,8 +726,10 @@
       real    :: URAMP, TT, DD, DQQ, QQ, TI, DQI, QI, PP
       integer :: IT
 
-      if (ieee_is_nan(TL)) call lgr%warning('DQSAT0: TL contains NaN')
-      if (ieee_is_nan(PL)) call lgr%warning('DQSAT0: PL contains NaN')
+      if (debugIsEnabled) then
+         if (ieee_is_nan(TL)) call lgr%warning('DQSAT0: TL contains NaN')
+         if (ieee_is_nan(PL)) call lgr%warning('DQSAT0: PL contains NaN')
+      end if
 
       if(present(RAMP)) then
          URAMP = -abs(RAMP)
@@ -730,11 +747,12 @@
          PP = PL*100.
       end if
 
-      if(URAMP==TMIX .OR. URAMP==0. .and. UTBL) then
+      if((URAMP==TMIX .OR. URAMP==0.) .and. UTBL) then
 
          if(FIRST) then
             FIRST = .false.
             call ESINIT
+            call LOGGER_INIT
          end if
 
          if    (TL<=TMINTBL) then
@@ -767,6 +785,11 @@
 
       else
 
+         if(FIRST) then
+            FIRST = .false.
+            call LOGGER_INIT
+         end if
+
          TI = TL - ZEROC
 
          if    (TI <= URAMP) then
@@ -795,8 +818,10 @@
       real :: DQSAT(size(TL,1))
       integer :: I
 
-      if (any(ieee_is_nan(TL))) call lgr%warning('DQSAT1: TL contains NaN')
-      if (any(ieee_is_nan(PL))) call lgr%warning('DQSAT1: PL contains NaN')
+      if (debugIsEnabled) then
+         if (any(ieee_is_nan(TL))) call lgr%warning('DQSAT1: TL contains NaN')
+         if (any(ieee_is_nan(PL))) call lgr%warning('DQSAT1: PL contains NaN')
+      end if
 
       do I=1,SIZE(TL,1)
          if (present(QSAT)) then
@@ -815,8 +840,10 @@
       real :: DQSAT(size(TL,1),size(TL,2))
       integer :: I, J
 
-      if (any(ieee_is_nan(TL))) call lgr%warning('DQSAT2: TL contains NaN')
-      if (any(ieee_is_nan(PL))) call lgr%warning('DQSAT2: PL contains NaN')
+      if (debugIsEnabled) then
+         if (any(ieee_is_nan(TL))) call lgr%warning('DQSAT2: TL contains NaN')
+         if (any(ieee_is_nan(PL))) call lgr%warning('DQSAT2: PL contains NaN')
+      end if
 
       do J=1,SIZE(TL,2)
          do I=1,SIZE(TL,1)
@@ -837,8 +864,10 @@
       real :: DQSAT(size(TL,1),size(TL,2),size(TL,3))
       integer :: I, J, K
 
-      if (any(ieee_is_nan(TL))) call lgr%warning('DQSAT3: TL contains NaN')
-      if (any(ieee_is_nan(PL))) call lgr%warning('DQSAT3: PL contains NaN')
+      if (debugIsEnabled) then
+         if (any(ieee_is_nan(TL))) call lgr%warning('DQSAT3: TL contains NaN')
+         if (any(ieee_is_nan(PL))) call lgr%warning('DQSAT3: PL contains NaN')
+      end if
 
       do K=1,SIZE(TL,3)
          do J=1,SIZE(TL,2)
@@ -896,7 +925,10 @@
             TMINICE    =  ZEROC + TMINSTR
          endif
 
-         if(UTBL) call ESINIT
+         if(UTBL) then
+            call ESINIT
+            call LOGGER_INIT
+         end if
 
          return
        end subroutine GEOS_QsatSet
@@ -915,8 +947,6 @@
 
           UT = UTBL
           UTBL=.false.
-
-          lgr => logging%get_logger('SHARED.GMAOSHARED.GEOSSHARED.QSAT')
 
           do I=1,TABLESIZE
 
@@ -947,6 +977,14 @@
 
        end subroutine ESINIT
 
+       subroutine LOGGER_INIT
+
+          implicit none
+
+          lgr => logging%get_logger('SHARED.GMAOSHARED.GEOSSHARED.QSAT')
+          debugIsEnabled = lgr%isEnabledFor(DEBUG)
+
+       end subroutine LOGGER_INIT
 
 
 

--- a/GEOS_Shared/GEOS_Utilities.F90
+++ b/GEOS_Shared/GEOS_Utilities.F90
@@ -10,6 +10,8 @@
 ! !USES:
 
   use MAPL_ConstantsMod
+  use pFlogger
+  use ieee_arithmetic
 
 ! #include "qsatlqu.code"
 ! #include "qsatice.code"
@@ -149,6 +151,8 @@
 
       real, save :: TMINLQU    =  ZEROC - 40.0
       real, save :: TMINICE    =  ZEROC + TMINSTR
+
+      class(Logger), pointer :: lgr
 
   contains
 
@@ -503,6 +507,9 @@
     real    :: URAMP, DD, QQ, TI, DQ, PP
     integer :: IT
 
+    if (ieee_is_nan(TL)) call lgr%warning(' QSAT0: TL contains NaN')
+    if (ieee_is_nan(PL)) call lgr%warning(' QSAT0: PL contains NaN')
+
     if(present(RAMP)) then
        URAMP = -abs(RAMP)
     else
@@ -583,6 +590,10 @@
       real,    optional, intent(OUT):: DQSAT(:)
       real :: QSAT(size(TL,1))
       integer :: I
+
+      if (any(ieee_is_nan(TL))) call lgr%warning(' QSAT1: TL contains NaN')
+      if (any(ieee_is_nan(PL))) call lgr%warning(' QSAT1: PL contains NaN')
+
       do I=1,SIZE(TL,1)
          if (present(DQSAT)) then
             QSAT(I) = QSAT0(TL(I),PL(I),RAMP,PASCALS,DQSAT(I))
@@ -599,6 +610,10 @@
       real,    optional, intent(OUT):: DQSAT(:,:)
       real :: QSAT(size(TL,1),size(TL,2))
       integer :: I, J
+
+      if (any(ieee_is_nan(TL))) call lgr%warning(' QSAT2: TL contains NaN')
+      if (any(ieee_is_nan(PL))) call lgr%warning(' QSAT2: PL contains NaN')
+
       do J=1,SIZE(TL,2)
          do I=1,SIZE(TL,1)
             if (present(DQSAT)) then
@@ -617,6 +632,10 @@
       real,    optional, intent(OUT):: DQSAT(:,:,:)
       real :: QSAT(size(TL,1),size(TL,2),size(TL,3))
       integer :: I, J, K
+
+      if (any(ieee_is_nan(TL))) call lgr%warning(' QSAT3: TL contains NaN')
+      if (any(ieee_is_nan(PL))) call lgr%warning(' QSAT3: PL contains NaN')
+
       do K=1,SIZE(TL,3)
          do J=1,SIZE(TL,2)
             do I=1,SIZE(TL,1)
@@ -691,6 +710,9 @@
       real    :: DQSAT
       real    :: URAMP, TT, DD, DQQ, QQ, TI, DQI, QI, PP
       integer :: IT
+
+      if (ieee_is_nan(TL)) call lgr%warning('DQSAT0: TL contains NaN')
+      if (ieee_is_nan(PL)) call lgr%warning('DQSAT0: PL contains NaN')
 
       if(present(RAMP)) then
          URAMP = -abs(RAMP)
@@ -772,6 +794,10 @@
       real,    optional, intent(OUT):: QSAT(:)
       real :: DQSAT(size(TL,1))
       integer :: I
+
+      if (any(ieee_is_nan(TL))) call lgr%warning('DQSAT1: TL contains NaN')
+      if (any(ieee_is_nan(PL))) call lgr%warning('DQSAT1: PL contains NaN')
+
       do I=1,SIZE(TL,1)
          if (present(QSAT)) then
             DQSAT(I) = DQSAT0(TL(I),PL(I),RAMP,PASCALS,QSAT(I))
@@ -788,6 +814,10 @@
       real,    optional, intent(OUT):: QSAT(:,:)
       real :: DQSAT(size(TL,1),size(TL,2))
       integer :: I, J
+
+      if (any(ieee_is_nan(TL))) call lgr%warning('DQSAT2: TL contains NaN')
+      if (any(ieee_is_nan(PL))) call lgr%warning('DQSAT2: PL contains NaN')
+
       do J=1,SIZE(TL,2)
          do I=1,SIZE(TL,1)
             if (present(QSAT)) then
@@ -806,6 +836,10 @@
       real,    optional, intent(OUT):: QSAT(:,:,:)
       real :: DQSAT(size(TL,1),size(TL,2),size(TL,3))
       integer :: I, J, K
+
+      if (any(ieee_is_nan(TL))) call lgr%warning('DQSAT3: TL contains NaN')
+      if (any(ieee_is_nan(PL))) call lgr%warning('DQSAT3: PL contains NaN')
+
       do K=1,SIZE(TL,3)
          do J=1,SIZE(TL,2)
             do I=1,SIZE(TL,1)
@@ -881,6 +915,8 @@
 
           UT = UTBL
           UTBL=.false.
+
+          lgr => logging%get_logger('SHARED.GMAOSHARED.GEOSSHARED.QSAT')
 
           do I=1,TABLESIZE
 


### PR DESCRIPTION
This PR is to add logger calls (at a WARNING level) for the QSAT and DQSAT codes. Recently, a case was found where a NaN was passed down into GEOS_QSAT and this led to a crash. With these loggers, the user would at least get a warning that a NaN was passed before the model inevitably crashes.

Example output is:
```
            QSAT: WARNING:  QSAT0: TL contains NaN
```

Also, runs were made with and without this code to determine if the `ieee_is_nan()` call was expensive or not. The results are below with Throughput (days/day): 

| Resolution | Stock | IEEE |
| - | - | - |
| c48 | 569.414  | 562.533 |
| c90 | 216.222  | 219.643 |
| c180 | 126.599  | 128.268 |
| c360 | 112.156  | 113.598 |
| c720 | 44.752 | 45.567 |

As can be seen there is little cost to the calls at least on the order of discover variablility. Wall Time shows a similar trend. Per @tclune, the expected expensive bit (initializing the logger) is done in the called-once `ESINIT` code.

**NOTE**: In truth, this should probably be a logging *error* not warning, but the best way to propagate errors up the stack is through the `_ASSERT()` and `_VERIFY()` macros. This code doesn't support this as they do not return RC codes. But, since a NaN should crash the code right after this, in a way this does...