### PR TITLE
Use CONFIGURE_DEPENDS with GLOB

### DIFF
--- a/.github/workflows/changelog-enforcer.yml
+++ b/.github/workflows/changelog-enforcer.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: dangoslen/changelog-enforcer@v1.4.0
+    - uses: dangoslen/changelog-enforcer@v1.5.1
       with:
         changeLogPath: 'CHANGELOG.md'
         skipLabel: 'Skip Changelog'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 ### Fixed
+
+- Use `CONFIGURE_DEPENDS` with `file(GLOB)` calls
+
 ### Removed
 ### Added
 

--- a/GEOS_Util/coupled_diagnostics/CMakeLists.txt
+++ b/GEOS_Util/coupled_diagnostics/CMakeLists.txt
@@ -1,7 +1,7 @@
 # From https://stackoverflow.com/questions/7787823/cmake-how-to-get-the-name-of-all-subdirectories-of-a-directory
 
 MACRO(SUBDIRLIST result curdir)
-  FILE(GLOB children RELATIVE ${curdir} ${curdir}/*)
+  FILE(GLOB children CONFIGURE_DEPENDS RELATIVE ${curdir} ${curdir}/*)
   SET(dirlist "")
   FOREACH(child ${children})
     IF(IS_DIRECTORY ${curdir}/${child})

--- a/GEOS_Util/plots/CMakeLists.txt
+++ b/GEOS_Util/plots/CMakeLists.txt
@@ -40,7 +40,7 @@ install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/quickstat DESTINATION plots)
 # From https://stackoverflow.com/questions/7787823/cmake-how-to-get-the-name-of-all-subdirectories-of-a-directory
 
 MACRO(SUBDIRLIST result curdir)
-  FILE(GLOB children RELATIVE ${curdir} ${curdir}/*)
+  FILE(GLOB children CONFIGURE_DEPENDS RELATIVE ${curdir} ${curdir}/*)
   SET(dirlist "")
   FOREACH(child ${children})
     IF(IS_DIRECTORY ${curdir}/${child})

--- a/GEOS_Util/post/CMakeLists.txt
+++ b/GEOS_Util/post/CMakeLists.txt
@@ -35,7 +35,7 @@ endif ()
 set_target_properties (stats.x PROPERTIES COMPILE_FLAGS "${BIG_ENDIAN}")
 ecbuild_add_executable (TARGET convert_aerosols.x SOURCES convert_aerosols.F)
 
-file(GLOB perlscripts *.pl)
+file(GLOB perlscripts CONFIGURE_DEPENDS *.pl)
 install(
    PROGRAMS ${perlscripts} ec2grd.csh
    DESTINATION bin)

--- a/GEOS_Util/pre/NSIDC-OSTIA_SST-ICE_blend/CMakeLists.txt
+++ b/GEOS_Util/pre/NSIDC-OSTIA_SST-ICE_blend/CMakeLists.txt
@@ -51,6 +51,6 @@ if (F2PY_FOUND)
    add_dependencies(read_ops_bcs ${this})
 endif (F2PY_FOUND)
 
-file(GLOB cshscripts *.csh)
-file(GLOB perlscripts *.pl)
+file(GLOB cshscripts CONFIGURE_DEPENDS *.csh)
+file(GLOB perlscripts CONFIGURE_DEPENDS *.pl)
 install(PROGRAMS ${cshscripts} ${perlscripts} DESTINATION bin)

--- a/GMAO_etc/CMakeLists.txt
+++ b/GMAO_etc/CMakeLists.txt
@@ -50,15 +50,15 @@ ecbuild_add_executable (
 
 ## bin ##
 
-file(GLOB perl_files *.pl)
+file(GLOB perl_files CONFIGURE_DEPENDS *.pl)
 # We must remove two files because of DASPERL
 list(REMOVE_ITEM perl_files
    ${CMAKE_CURRENT_SOURCE_DIR}/Err_Log.pl 
    ${CMAKE_CURRENT_SOURCE_DIR}/fndate.pl
    )
 
-file(GLOB perl_packages *.pm)
-file(GLOB python_files *.py)
+file(GLOB perl_packages CONFIGURE_DEPENDS *.pm)
+file(GLOB python_files CONFIGURE_DEPENDS *.py)
 
 set(perlscripts
    acquire
@@ -116,8 +116,8 @@ endforeach ()
 
 ## etc ##
 
-file(GLOB obsys_rc obsys*.rc)
-file(GLOB templates *.tmpl)
+file(GLOB obsys_rc CONFIGURE_DEPENDS obsys*.rc)
+file(GLOB templates CONFIGURE_DEPENDS *.tmpl)
 
 install (
    FILES ${obsys_rc} ${templates} pesto.arc PUBLICTAG

--- a/GMAO_hermes/CMakeLists.txt
+++ b/GMAO_hermes/CMakeLists.txt
@@ -88,5 +88,5 @@ endif ()
 
 ecbuild_add_executable (TARGET write_eta.x      SOURCES write_eta.F90      LIBS ${this})
 
-file(GLOB resource_files *.rc)
+file(GLOB resource_files CONFIGURE_DEPENDS *.rc)
 install(FILES ${resource_files} DESTINATION etc)


### PR DESCRIPTION
When a `GLOB` is used in CMake, the CMake system doesn't check to see if files in the `GLOB` change when re-running `cmake`. Thus if someone adds/removes a file that the `GLOB` would pick up, say, CMake might not see there is a change and things go a bit pear-shaped. But there is [a `CONFIGURE_DEPENDS` flag](https://cmake.org/cmake/help/latest/command/file.html#glob):

> If the CONFIGURE_DEPENDS flag is specified, CMake will add logic to the main build system check target to rerun the flagged GLOB commands at build time. If any of the outputs change, CMake will regenerate the build system.

While CMake prefers no `GLOB` at all (as `CONFIGURE_DEPENDS` isn't supported for all generators), for now this is a possible partial solution until the CMake could be rewritten to explicitly list all files. 