### PR TITLE
Update flags for zonal.f to match CVS; fix zonal.gs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Fixed
 
-- Fixed compilation flags for `zonal.f`
+- Fixed compilation flags for `zonal.f` to match that of CVS
 - Fixed bug in `res/zonal.gs` for `zonal.x` location
 - Added flag to regrid_forcing_esmf.x to force a 0 to 1 range when regridding files that should fractions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 ### Fixed
+
+- Fixed compilation flags for `zonal.f`
+- Fixed bug in `res/zonal.gs` for `zonal.x` location
+
 ### Removed
 ### Added
 

--- a/GEOS_Util/plots/CMakeLists.txt
+++ b/GEOS_Util/plots/CMakeLists.txt
@@ -1,3 +1,8 @@
+if (CMAKE_Fortran_COMPILER_ID MATCHES Intel AND CMAKE_BUILD_TYPE MATCHES Release)
+   set( CMAKE_Fortran_FLAGS_RELEASE "${FOPT2} ${PP}")
+   message(STATUS "CMAKE_Fortran_FLAGS_RELEASE: ${CMAKE_Fortran_FLAGS_RELEASE}")
+endif ()
+
 set (zonal_prog_name
    zonal_${CMAKE_SYSTEM_NAME}.x
    )

--- a/GEOS_Util/plots/CMakeLists.txt
+++ b/GEOS_Util/plots/CMakeLists.txt
@@ -1,6 +1,5 @@
 if (CMAKE_Fortran_COMPILER_ID MATCHES Intel AND CMAKE_BUILD_TYPE MATCHES Release)
    set( CMAKE_Fortran_FLAGS_RELEASE "${FOPT2} ${PP}")
-   message(STATUS "CMAKE_Fortran_FLAGS_RELEASE: ${CMAKE_Fortran_FLAGS_RELEASE}")
 endif ()
 
 set (zonal_prog_name

--- a/GEOS_Util/plots/res/zonal.gs
+++ b/GEOS_Util/plots/res/zonal.gs
@@ -212,8 +212,8 @@ endwhile
 
 * Run Fortran Code to Produce StreamFunction and Residual Circulation
 * -------------------------------------------------------------------
-say ' 'geosutil'/plots/zonal_'arch'.x -tag 'expid' -desc 'descm
-'!    'geosutil'/plots/zonal_'arch'.x -tag 'expid' -desc 'descm
+say ' 'geosutil'/bin/zonal_'arch'.x -tag 'expid' -desc 'descm
+'!    'geosutil'/bin/zonal_'arch'.x -tag 'expid' -desc 'descm
 
 '!remove sedfile'
 '!touch  sedfile'
@@ -469,8 +469,8 @@ endwhile
 
 * Run Fortran Code to Produce StreamFunction and Residual Circulation
 * -------------------------------------------------------------------
-say ' 'geosutil'/plots/zonal_'arch'.x -tag 'obsid' -desc 'desco
-'!    'geosutil'/plots/zonal_'arch'.x -tag 'obsid' -desc 'desco
+say ' 'geosutil'/bin/zonal_'arch'.x -tag 'obsid' -desc 'desco
+'!    'geosutil'/bin/zonal_'arch'.x -tag 'obsid' -desc 'desco
 
 '!remove sedfile'
 '!touch  sedfile'


### PR DESCRIPTION
Per @lltakacs it was found that `zonal.f` was being compiled differently in git than in CVS. This seemed to be causing issues. This is a PR to update the CMake. Note that @lltakacs says there seem to still be issues beyond this. But this is a placeholder for now until he or @sdrabenh can figure it out.