### PR TITLE
Add partition option for regrid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Changed
+
+- Added `-partition` option to `regrid.pl`
+
 ### Fixed
 ### Removed
 ### Added

--- a/GEOS_Util/post/regrid.pl
+++ b/GEOS_Util/post/regrid.pl
@@ -1056,8 +1056,8 @@ sub check_inputs {
     #-----------------------------------------
     if ($outdir =~ /archive/ and $CS{$grOUT} and $upairFLG) {
         warn "\n=======\nWARNING\n=======\n"
-            ."> CS upper-air restarts are created with a PBS job.\n"
-            ."> PBS jobs cannot write to the archive directories.\n"
+            ."> CS upper-air restarts are created with a batch job.\n"
+            ."> Batch jobs cannot write to the archive directories.\n"
             ."> Your OUTPUT directory appears to be in the archives.\n\n"
             ."outdir: $outdir\n\n";
         $ans = query("Quit (y/n)", "y");
@@ -2257,7 +2257,7 @@ sub copy_upperair_rsts {
 
 #=======================================================================
 # name - regrid_upperair_rsts_CS
-# purpose - set up and submit PBS job to perform conversion to
+# purpose - set up and submit batch job to perform conversion to
 #           cubed-sphere upper-air restarts
 #=======================================================================
 sub regrid_upperair_rsts_CS {
@@ -2505,7 +2505,7 @@ EOF
 
         system_("$regridj 1>$qcmdlog 2>&1") && die "Error with $regridj;";
     } else {
-        print_("\nThe CS regridding is MPI based; submitting job to PBS\n");
+        print_("\nThe CS regridding is MPI based; submitting job to batch system\n");
         system_("$qcmd $qwaitFLG -o $qcmdlog $regridj");
     }
     chdir_($workdir, $verbose);


### PR DESCRIPTION
This PR adds a `-partition` option to `regrid.pl`.

Note that this PR is dependent on https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/392 as we need to pass the `-partition` down to `mk_restarts`