### PR TITLE
Update changelog enforcer

### DIFF
--- a/.github/workflows/changelog-enforcer.yml
+++ b/.github/workflows/changelog-enforcer.yml
@@ -12,4 +12,4 @@ jobs:
     - uses: dangoslen/changelog-enforcer@v1.6.0
       with:
         changeLogPath: 'CHANGELOG.md'
-        skipLabels: 'Skip Changelog,0 diff trivial'
+        skipLabels: '"Skip Changelog","0 diff trivial"'

--- a/.github/workflows/changelog-enforcer.yml
+++ b/.github/workflows/changelog-enforcer.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: dangoslen/changelog-enforcer@issue-58
+    - uses: dangoslen/changelog-enforcer@v1.6.1
       with:
         changeLogPath: 'CHANGELOG.md'
         skipLabels: 'Skip Changelog,0 diff trivial'

--- a/.github/workflows/changelog-enforcer.yml
+++ b/.github/workflows/changelog-enforcer.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: dangoslen/changelog-enforcer@v1.5.1
+    - uses: dangoslen/changelog-enforcer@v1.6.0
       with:
         changeLogPath: 'CHANGELOG.md'
-        skipLabel: 'Skip Changelog'
+        skipLabels: 'Skip Changelog,0 diff trivial'

--- a/.github/workflows/changelog-enforcer.yml
+++ b/.github/workflows/changelog-enforcer.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: dangoslen/changelog-enforcer@v1.6.0
+    - uses: dangoslen/changelog-enforcer@issue-58
       with:
         changeLogPath: 'CHANGELOG.md'
-        skipLabels: '"Skip Changelog","0 diff trivial"'
+        skipLabels: 'Skip Changelog,0 diff trivial'


### PR DESCRIPTION
The changelog enforcer is deprecating `skipLabel` for `skipLabels` allowing for more than one label to skip the changelog, like, say, 0-diff trivial. This updates