### PR TITLE
Update changelog enforcer [skip ci]

### DIFF
--- a/.github/workflows/changelog-enforcer.yml
+++ b/.github/workflows/changelog-enforcer.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: dangoslen/changelog-enforcer@v1.5.1
+    - uses: dangoslen/changelog-enforcer@v1.6.1
       with:
         changeLogPath: 'CHANGELOG.md'
-        skipLabel: 'Skip Changelog'
+        skipLabels: 'Skip Changelog,0 diff trivial'


### PR DESCRIPTION
This update allows 0-diff trivial PRs to not need to update `CHANGELOG.md` which should make @sdrabenh and others happier. 😄 