### PR TITLE
Update atmOceanIntLayer.F90 (protections for AOIL v0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [??] - 2021-02-05
+
+### Added 
+
+- protections to AOIL v0 in atmOcnIntlayer
+
 ## [1.3.6] - 2021-01-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added 
 
-- protections to AOIL v0 in atmOcnIntlayer
+- safeguards on TSKINWTR over sea ice (AOIL version: v0) in atmOcnIntlayer
 
 ## [1.3.6] - 2021-01-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added 
 
-- safeguards on TSKINWTR over sea ice (AOIL version: v0) in atmOcnIntlayer
+- Sync atmOcnIntlayer with that in GEOS-FP GEOS-5.27.1 (02/2021) GEOSadas-5_27_1_p3
 
 ## [1.3.6] - 2021-01-12
 

--- a/GEOS_Shared/atmOceanIntLayer.F90
+++ b/GEOS_Shared/atmOceanIntLayer.F90
@@ -422,9 +422,7 @@ contains
                 DCOOL_(N)  = min( LCOOL_(N)*NU_WATER/USTARW_(N), 1.e-2)  ! Prevent very thick cool layer depth
              end if
 
-! Note: that if QCOOL gets to be excessively large due to non-solar fluxes (i.e., downwelling longwave, latent and sensible), say over sea ice,
-! TDROP gets to be unrealistically large. From measurements we know it is typically less than 1.0K. So threshold it be less than 1.
-             TDROP_(N)    = min( max(0.0, DCOOL_(N)*QCOOL_(N)/TherCond_WATER), 1.0) ! Eqn(4) & (13) of F96
+             TDROP_(N)    = max(0.0, DCOOL_(N)*QCOOL_(N)/TherCond_WATER) ! Eqn(4) & (13) of F96
 
           end do COOL_SKIN
 

--- a/GEOS_Shared/atmOceanIntLayer.F90
+++ b/GEOS_Shared/atmOceanIntLayer.F90
@@ -515,10 +515,10 @@ contains
 ! Also limit diurnal warming contribution to be < 5K: based on observations
 ! -------------------------------------------------------------------
 
-             TW(N) = TS_FOUNDi(N) + min( (1.0/(1.+X2))*(TBAR_(N) - TS_FOUNDi(N)), 5.)
+             TW(N) = TS_FOUNDi(N) + (1.0/(1.+X2))*(TBAR_(N) - TS_FOUNDi(N))
              TS(N) = TS(N)  + ((1.0+MUSKIN)/MUSKIN) *    (TW(N)    - TBAR_(N))
 
-             TDEL_(N)    = TS_FOUNDi(N) + min( ((1.0+MUSKIN)/MUSKIN)*MAX(TW(N)- TS_FOUNDi(N), 0.0), 5.)
+             TDEL_(N)    = TS_FOUNDi(N) + ((1.0+MUSKIN)/MUSKIN)*MAX(TW(N)- TS_FOUNDi(N), 0.0)
              TBAR_(N)    = TW(N)
 
              TS(N)    = TDEL_(N) - TDROP_(N)

--- a/GEOS_Shared/atmOceanIntLayer.F90
+++ b/GEOS_Shared/atmOceanIntLayer.F90
@@ -512,7 +512,6 @@ contains
              endif
 
 ! We DO NOT include cool-skin tdrop in TW, therefore, we now save TW
-! Also limit diurnal warming contribution to be < 5K: based on observations
 ! -------------------------------------------------------------------
 
              TW(N) = TS_FOUNDi(N) + (1.0/(1.+X2))*(TBAR_(N) - TS_FOUNDi(N))

--- a/GEOS_Shared/atmOceanIntLayer.F90
+++ b/GEOS_Shared/atmOceanIntLayer.F90
@@ -422,7 +422,9 @@ contains
                 DCOOL_(N)  = min( LCOOL_(N)*NU_WATER/USTARW_(N), 1.e-2)  ! Prevent very thick cool layer depth
              end if
 
-             TDROP_(N)    = max( 0.0, DCOOL_(N)*QCOOL_(N)/TherCond_WATER ) ! Eqn(4) & (13) of F96
+! Note: that if QCOOL gets to be excessively large due to non-solar fluxes (i.e., downwelling longwave, latent and sensible), say over sea ice,
+! TDROP gets to be unrealistically large. From measurements we know it is typically less than 1.0K. So threshold it be less than 1.
+             TDROP_(N)    = min( max(0.0, DCOOL_(N)*QCOOL_(N)/TherCond_WATER), 1.0) ! Eqn(4) & (13) of F96
 
           end do COOL_SKIN
 
@@ -512,11 +514,13 @@ contains
              endif
 
 ! We DO NOT include cool-skin tdrop in TW, therefore, we now save TW
+! Also limit diurnal warming contribution to be < 5K: based on observations
+! -------------------------------------------------------------------
 
-             TW(N) = TS_FOUNDi(N) + ( 1.0/(1.+X2))  *    (TBAR_(N) - TS_FOUNDi(N))
+             TW(N) = TS_FOUNDi(N) + min( (1.0/(1.+X2))*(TBAR_(N) - TS_FOUNDi(N)), 5.)
              TS(N) = TS(N)  + ((1.0+MUSKIN)/MUSKIN) *    (TW(N)    - TBAR_(N))
 
-             TDEL_(N)    = TS_FOUNDi(N) + ((1.0+MUSKIN)/MUSKIN) * MAX(TW(N)    - TS_FOUNDi(N), 0.0)
+             TDEL_(N)    = TS_FOUNDi(N) + min( ((1.0+MUSKIN)/MUSKIN)*MAX(TW(N)- TS_FOUNDi(N), 0.0), 5.)
              TBAR_(N)    = TW(N)
 
              TS(N)    = TDEL_(N) - TDROP_(N)

--- a/GEOS_Shared/atmOceanIntLayer.F90
+++ b/GEOS_Shared/atmOceanIntLayer.F90
@@ -350,6 +350,7 @@ contains
     integer         :: N, iter_cool
     real            :: ALPH, Qb, fC, fLA, X1, X2, dTw
 
+    real, parameter :: TICE            = MAPL_TICE-1.8      ! -1.8C freezing temperature of sea water
     real, parameter :: RHO_SEAWATER    = 1022.0  ! sea water density             [kg/m^3]    ! Replace Usage of RHO_SEAWATER with MAPL_RHO_SEAWATER
     real, parameter :: NU_WATER        = 1.0E-6  ! kinematic viscosity of water  [m^2/s]
     real, parameter :: TherCond_WATER  = 0.563   ! Thermal conductivity of water [W/m/ K]
@@ -521,10 +522,13 @@ contains
              TBAR_(N)    = TW(N)
 
              TS(N)    = TDEL_(N) - TDROP_(N)
-             TWMTS(N) = TW(N)    - TS(N)
              TWMTF(N) = 0.0
 !            TWMTF(N) = TW(N)    - TS_FOUNDi(N)  ! This will cause non-zero diff in internal/checkpoint, but ZERO DIFF in OUTPUT.
           end if WARM_LAYER
+          
+          ! Protection on minimum water temperture, do not allow colder than TICE
+          TW(N)    = MAX(TW(N),TICE)
+          TWMTS(N) = TW(N)    - TS(N)
 
        else            ! FR(N) <= fr_ice_thresh
           DCOOL_ (N)     = MAPL_UNDEF
@@ -537,6 +541,7 @@ contains
           SWCOOL_(N)     = MAPL_UNDEF
           BCOOL_ (N)     = MAPL_UNDEF
           TDEL_  (N)     = MAPL_UNDEF
+          TW     (N)     = TICE
           TWMTS  (N)     = 0.0
           TWMTF  (N)     = 0.0
           QWARM_ (N)     = MAPL_UNDEF


### PR DESCRIPTION
This update was implemented as `TSKINWTR patch` in GEOS FP system [GEOS-5.27.1](https://gmao.gsfc.nasa.gov/news/geos_system_news/2021/planned_GEOS_FP_upgrade_5_27_1.php)
Therefore it can be found (per @rtodling) in:
>CVS tag:  GEOSadas-5_27_1_p3

Please see `GEOS_OpenWaterGridComp.F90`. Of course, _this_ git based model version has it all re-organized, but **zero-diff** following https://github.com/GEOS-ESM/GEOSgcm/releases/tag/v10.16.1

**Description of the update**:
- Limit `TW, TWMTS` to `-1.8C` whenever `FR(N) <= fr_ice_thresh`. Note: the `default` value of  `fr_ice_thresh` is 0.0 and `FR` is positive definite, i.e., it is **never** < 0.

This addition is non-zero-diff, and essentially syncs the atmosphere-ocean interface layer with what is being used by the [GMAO FP system GEOS-5.27.1](https://gmao.gsfc.nasa.gov/news/geos_system_news/2021/planned_GEOS_FP_upgrade_5_27_1.php), and is the only reason for this PR.

#### Notes:
This update has actually exposed 2 issues (1 already known):
1. [**known issue**] that the internal state variables: `TW, TWMTS` are _poor_ choices! which have already been replaced by a single _better_ one: `TMWTF`, used in the GMAO S2S v3; however, the FP system does not, reasons were [summarized in this issue](https://github.com/GEOS-ESM/GEOSgcm_GridComp/issues/356).
2. [**now exposed**] Regardless of the choice of the internal state, in `GEOS_OpenWaterGridComp.F90` the fraction of water `FR` should be > 0, since its job is to operate over variables defined on water, again, where `FR water > 0`, needless to say, `FR water == 0` means its sea ice! So this issue brings to our attention the _need_ to treat variables where there is sea ice in  `GEOS_OpenWaterGridComp.F90`, which by design is the job of the sea ice child. Clearly either the parent: `GEOS_SaltWaterGridComp.F90` and/or its two children namely: `GEOS_SimpleSeaiceGridComp.F90, GEOS_OpenWaterGridComp.F90` are flawed! It is possible that this issue manifests in coupled simulations as well, where the sea ice child is: `GEOS_CICE4ColumnPhysGridComp.F90` instead of `GEOS_SimpleSeaiceGridComp.F90`.