### PR TITLE
Bug fix for issue #99: Edge level arrays out-of-bounds in Lighting_mod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
+
+- Fix for out-of-bounds error in lightning module (#99)
+
 ### Changed
 ### Added
 ### Removed

--- a/GEOS_Shared/Lightning_mod.F90
+++ b/GEOS_Shared/Lightning_mod.F90
@@ -913,8 +913,8 @@ end subroutine getLightning
       ALLOCATE(ltop2d (1:IM, 1:JM),   STAT=RC)
 
       ! edge layer fields
-      pleHemco(:,:,1:KM) = ple(:,:,KM:1:-1)
-      cnvMfcHemco(:,:,1:KM) = cnvMfc(:,:,KM:1:-1)
+      pleHemco(:,:,1:KM) = ple(:,:,LM:0:-1)
+      cnvMfcHemco(:,:,1:KM) = cnvMfc(:,:,LM:0:-1)
 
       ! fields at grid box center
       airTempHemco(:,:,1:LM) = airTemp(:,:,LM:1:-1)
@@ -925,7 +925,7 @@ end subroutine getLightning
 
 
       do levCount=1,LM
-         gridBoxHeightHemco(:,:,levCount) = geoPotHeight(:,:,levCount) - geoPotHeight(:,:,levCount+1)
+         gridBoxHeightHemco(:,:,levCount) = geoPotHeight(:,:,levCount-1) - geoPotHeight(:,:,levCount)
       enddo
       gridBoxHeightHemco2(:,:,1:LM) = gridBoxHeightHemco(:,:,LM:1:-1)
 


### PR DESCRIPTION
This is a bug fix for the following issue: https://github.com/GEOS-ESM/GMAO_Shared/issues/99

Arrays ple and cnvMfc are now referenced using the indices LM:0 (instead of LM+1:1):

```
      pleHemco(:,:,1:KM) = ple(:,:,LM:0:-1)
      cnvMfcHemco(:,:,1:KM) = cnvMfc(:,:,LM:0:-1)
```

Similarly, the index was shifted by -1 for array geoPotHeight so that it now spans the valid range:

```
      do levCount=1,LM
         gridBoxHeightHemco(:,:,levCount) = geoPotHeight(:,:,levCount-1) - geoPotHeight(:,:,levCount)
      enddo
```

