### PR TITLE
Add Python Transition Team Codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,5 +18,9 @@
 # Yuri owns the coupled plots
 /GEOS_Util/coupled_diagnostics/ @yvikhlya 
 
+# The Python Transition Team will own Python files
+# until the Python 3 transition is completed
+*.py @GEOS-ESM/python-transition-team
+
 # The GEOS CMake Team is the CODEOWNER for the CMakeLists.txt files in this repository
 CMakeLists.txt @GEOS-ESM/cmake-team


### PR DESCRIPTION
As we prepare for the Python 3 Transition, add @GEOS-ESM/python-transition-team to the `CODEOWNERS` file.