### PR TITLE
Fixed CMake bugs for DAS build only libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
+- Fixed build for directories that are built as part of the GEOSdas
 
 ### Changed
 

--- a/GEOS_Pert/GEOS_PertShared/CMakeLists.txt
+++ b/GEOS_Pert/GEOS_PertShared/CMakeLists.txt
@@ -2,6 +2,6 @@ esma_set_this ()
 
 esma_add_library (${this}
   SRCS GEOS_PertSharedMod.F90
-  DEPENDENCIES MAPL_cfio_r4 MAPL_Base GMAO_mpeu GMAO_hermes
+  DEPENDENCIES MAPL_cfio_r4 MAPL GMAO_mpeu GMAO_hermes
   INCLUDES ${INC_ESMF})
 

--- a/GEOS_Pert/GEOS_PertSvecs/CMakeLists.txt
+++ b/GEOS_Pert/GEOS_PertSvecs/CMakeLists.txt
@@ -11,5 +11,5 @@ set (SRCS
 
 esma_add_library (${this}
   SRCS ${SRCS}
-  DEPENDENCIES MAPL_cfio_r4 MAPL_Base GMAO_mpeu GEOS_PertShared
+  DEPENDENCIES MAPL_cfio_r4 MAPL GMAO_mpeu GEOS_PertShared
   INCLUDES ${INC_ESMF})

--- a/arpack/SRC/CMakeLists.txt
+++ b/arpack/SRC/CMakeLists.txt
@@ -25,5 +25,4 @@ esma_add_library (${this}
   SRCS ${SRCS}
   )
 
-
-target_include_directories (${this} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)


### PR DESCRIPTION
When trying to build the DAS with the latest GMAO_Shared they do not sparse out arpack and the cmake command was failing. This fixes it.