### PR TITLE
Fix CHANGELOG for recent releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+### Changed
+
+### Added
+
+### Removed
+
+## [1.3.10] - 2021-04-02
+
+### Changed
+
+- Multiple updates brought over from GEOSadas work (see #166)
+
+## [1.3.9] - 2021-03-17
+
+### Fixed
+
 - Fix for out-of-bounds error in lightning module (#99)
 
 ### Changed
 
 - Stats plot updates
-- Multiple updates brought over from GEOSadas work (see #166)
 
 ### Added
 


### PR DESCRIPTION
For some reason, the CHANGELOG was not updated quite right for recent releases. This gets it back on track