### PR TITLE
Update main regrid.pl a la #174

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- In `regrid.pl`: Fixed the -wemin and -wemout options so that they will accept integer values; Also added Jason-NL BCS tag choice
+
 ### Changed
 
 ### Removed

--- a/GEOS_Util/post/regrid.pl
+++ b/GEOS_Util/post/regrid.pl
@@ -272,8 +272,8 @@ sub init {
                "catch"           => \$mk_catch,
                "catchcn"         => \$mk_catchcn,
                "route"           => \$mk_route,
-               "wemin"           => \$wemIN,
-               "wemout"          => \$wemOUT,
+               "wemin=i"         => \$wemIN,
+               "wemout=i"        => \$wemOUT,
                "bkg!"            => \$bkgFLG,
                "lbl!"            => \$lblFLG,
                "lcv!"            => \$lcvFLG,
@@ -465,7 +465,7 @@ sub init_tag_arrays_and_hashes {
 
     # BCS Tags: Icarus-NLv3 (New Land Parameters)
     #---------------------------------------------------------------------------
-    @INL  = qw( INL Icarus-NL Icarus-NLv3 );
+    @INL  = qw( INL Icarus-NL Icarus-NLv3 Jason-NL );
 
     foreach (@F14)   { $landIceVER{$_} = 1; $bcsTAG{$_} = "Fortuna-1_4" }
     foreach (@F20)   { $landIceVER{$_} = 1; $bcsTAG{$_} = "Fortuna-2_0" }


### PR DESCRIPTION
This is a `main` line update to `regrid.pl` to mirror that from @gmao-jstassi in #174. Per #174:

> Fixed the -wemin and -wemout options so that they will accept integer values; Also added Jason-NL BCS tag choice

