### PR TITLE
Zero-diff bug fix preventing out-of-bounds error when calculating GEOS-Chem lightning flash rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+Bugfix to prevent a seg-fault when calculating the lightning flash rate implemented in HEMCO/GEOS-Chem.
+
 ### Changed
 
 ### Removed

--- a/GEOS_Shared/Lightning_mod.F90
+++ b/GEOS_Shared/Lightning_mod.F90
@@ -877,6 +877,7 @@ end subroutine getLightning
 
       integer :: shape3d (3)
       integer :: IM, JM, LM, KM
+      integer :: LB, UB 
       integer :: levCount, kR
 
       real, parameter :: MIN_TO_SEC = 1.0/60.0
@@ -913,8 +914,10 @@ end subroutine getLightning
       ALLOCATE(ltop2d (1:IM, 1:JM),   STAT=RC)
 
       ! edge layer fields
-      pleHemco(:,:,1:KM) = ple(:,:,LM:0:-1)
-      cnvMfcHemco(:,:,1:KM) = cnvMfc(:,:,LM:0:-1)
+      LB = LBOUND(ple,3)
+      UB = UBOUND(ple,3)
+      pleHemco(:,:,1:KM) = ple(:,:,UB:LB:-1)
+      cnvMfcHemco(:,:,1:KM) = cnvMfc(:,:,UB:LB:-1)
 
       ! fields at grid box center
       airTempHemco(:,:,1:LM) = airTemp(:,:,LM:1:-1)
@@ -923,9 +926,9 @@ end subroutine getLightning
       ! turned on in CalcFlashRate below - but it's hardcoded to false.
       buoyancyHemco(:,:,1:LM) = real(-1) !buoyancy(:,:,LM:1:-1)
 
-
+      LB = LBOUND(geoPotHeight,3)
       do levCount=1,LM
-         gridBoxHeightHemco(:,:,levCount) = geoPotHeight(:,:,levCount-1) - geoPotHeight(:,:,levCount)
+         gridBoxHeightHemco(:,:,levCount) = geoPotHeight(:,:,levCount+LB-1) - geoPotHeight(:,:,levCount+LB)
       enddo
       gridBoxHeightHemco2(:,:,1:LM) = gridBoxHeightHemco(:,:,LM:1:-1)
 


### PR DESCRIPTION
This PR accompanies [PR #430 in GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/430). It prevents a seg-fault when calculating the lightning flash rate implemented in HEMCO/GEOS-Chem. Instead of explicitly assuming the lower and upper bound indeces of the array on model edges, it uses LBOUND and UBOUND instead. This seems to be necessary to prevent an out-of-bounds error in arrays `ple`, `cnvMfc`, and `geoPotHeight`.

This PR is zero-diff and fixes a problem that only showed up when requesting diagnostics `LFR_GCC` in combination with a replay simulation.

