### PR TITLE
Fixes some CMake Fortran_MODULE_DIRECTORY

### DIFF
--- a/GEOS_Util/post/CMakeLists.txt
+++ b/GEOS_Util/post/CMakeLists.txt
@@ -28,11 +28,14 @@ ecbuild_add_executable (TARGET binarytile.x SOURCES binarytile.F90)
 ecbuild_add_executable (TARGET rs_numtiles.x SOURCES rs_numtiles.F90)
 ecbuild_add_executable (TARGET rs_vinterp.x SOURCES rs_vinterp.F90)
 ecbuild_add_executable (TARGET rs_vinterp_scm.x SOURCES rs_vinterp_scm.F90)
+
 ecbuild_add_executable (TARGET stats.x SOURCES stats.F90)
 if (DISABLE_FIELD_WIDTH_WARNING)
   set_target_properties (stats.x PROPERTIES COMPILE_FLAGS ${DISABLE_FIELD_WIDTH_WARNING})
 endif ()
 set_target_properties (stats.x PROPERTIES COMPILE_FLAGS "${BIG_ENDIAN}")
+set_target_properties(stats.x PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
+
 ecbuild_add_executable (TARGET convert_aerosols.x SOURCES convert_aerosols.F)
 
 file(GLOB perlscripts CONFIGURE_DEPENDS *.pl)

--- a/GEOS_Util/pre/NSIDC-OSTIA_SST-ICE_blend/CMakeLists.txt
+++ b/GEOS_Util/pre/NSIDC-OSTIA_SST-ICE_blend/CMakeLists.txt
@@ -21,26 +21,31 @@ ecbuild_add_executable (
   TARGET regrid_forcing.x
   SOURCES regrid_forcing.F90
   LIBS ${this})
+set_target_properties(regrid_forcing.x PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
 
 ecbuild_add_executable (
   TARGET regrid_forcing_esmf.x
   SOURCES regrid_forcing_esmf.F90
   LIBS ${this})
+set_target_properties(regrid_forcing_esmf.x PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
 
 ecbuild_add_executable (
   TARGET sst_sic_EIGTHdeg.x
   SOURCES proc_SST_FRACI.F90
   LIBS ${this})
+set_target_properties(sst_sic_EIGTHdeg.x PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
 
 ecbuild_add_executable (
   TARGET sst_sic_QUARTdeg.x
   SOURCES proc_SST_FRACI_ostia_quart.F90
   LIBS ${this})
+set_target_properties(sst_sic_QUARTdeg.x PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
 
 ecbuild_add_executable (
   TARGET lake_sst_sic_EIGTHdeg.x
   SOURCES lake_data_EIGTHdeg.F90
   LIBS ${this})
+set_target_properties(lake_sst_sic_EIGTHdeg.x PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
 
 if (USE_F2PY)
    find_package(F2PY2)


### PR DESCRIPTION
This is some CMake changes mainly to prevent `.mod` files from being in the `build/src` directory tree. 

Most of GEOS will put its `.mod` files in a `build/include` directory based on the library being made. So, for example, the `.mod` files for Moist are in `build/include/GEOSmoist_GridComp/`. And the GEOS CMake framework handles this 99% of the time. But in a few places, we find `.mod` files not yet in the `build/include` tree. This fixes those.

This is one of those "If it builds, it's zero-diff" PRs since the only changes are to the build and not to any source codes.