### PR TITLE
Updates for MVAPICH2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Changed `esma_mpirun` for MVAPICH2
+
 ### Removed
 
 ## [1.4.3] - 2021-06-11

--- a/GMAO_etc/esma_mpirun
+++ b/GMAO_etc/esma_mpirun
@@ -220,7 +220,7 @@ sub which_mpi_cmd {
        # For now use mpirun_rsh. At NCCS this should be
        # srun -n but as -np is *external* to esma_mpirun
        # this requires wholesale script changes
-       chomp($mpicmd = `which mpirun_rsh`);
+       chomp($mpicmd = `which mpiexec.mpirun_rsh`);
     } else {
        # Used by both Intel MPI and Open MPI
        chomp($mpicmd = `which mpirun`);
@@ -251,7 +251,7 @@ sub get_xtraflags {
 
     # flags needed for mvapich2 mpi
     #------------------------------
-    $xtraflags .= "-export -hostfile \$PBS_NODEFILE" if $mpi_type eq "mvapich2";
+    $xtraflags .= "-export" if $mpi_type eq "mvapich2";
 
     # flags needed for intel mpi
     #---------------------------


### PR DESCRIPTION
These are updates for (re-)enabling MVAPICH2 with GEOS.  This changes the command `esma_mpirun` uses for MVAPICH2.

Should be taken in concert with https://github.com/GEOS-ESM/GEOSgcm_App/pull/239 (not *required*, just for best performance)