### PR TITLE
Update changelog enforcer

### DIFF
--- a/.github/workflows/changelog-enforcer.yml
+++ b/.github/workflows/changelog-enforcer.yml
@@ -9,7 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: dangoslen/changelog-enforcer@v1.6.1
+    - uses: dangoslen/changelog-enforcer@v2
       with:
         changeLogPath: 'CHANGELOG.md'
-        skipLabels: 'Skip Changelog,0 diff trivial'
+        skipLabels: 'Skip Changelog'
+        missingUpdateErrorMessage: >
+            No update to CHANGELOG.md found! Please add a changelog
+            entry to it describing your change.  Please note that the
+            keepachangelog (https://keepachangelog.com) format is
+            used. If your change is very trivial not applicable for a
+            changelog entry, add a 'Skip Changelog' label to the pull
+            request to skip the changelog enforcer.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+### Added
+### Fixed
+### Changed
+### Removed
+
+## [1.4.4] - 2021-06-25
    
 ### Added
 
 - Add new `echorc.pl` script (alternative to `echorc.x`)
-
-### Fixed
+- Added 181 levs to `GMAO_hermes/dyn2dyn.f90` and a frequency change in `GMAO_etc/obsys-nccs.rc`
 
 ### Changed
 
 - Changed `esma_mpirun` for MVAPICH2
-
-### Removed
 
 ## [1.4.3] - 2021-06-11
 


### PR DESCRIPTION
This is an update to the changelog enforcer that now allows a more exciting error message. Unfortunately, the error is only on the Details of the check, but now it's *nice and explicit*!

Also, remove the ability for 0-diff trivial PRs to skip. Too many PRs are labeled as trivial when they aren't!