### PR TITLE
change the CN_VERSION and restart name

### DIFF
--- a/GEOS_Util/post/regrid.pl
+++ b/GEOS_Util/post/regrid.pl
@@ -1579,9 +1579,25 @@ sub check_rst_files {
             else       { $notfound{$type} = 1 }
         }
         foreach $type (keys %notfound) {
-            next if $type eq "catchcn${cnlist[0]}_internal_rst";
             $SURFACE{$type} = 0;
             $swFLG = 1;
+            if ($type eq "catchcn${cnlist[0]}_internal_rst") { 
+               $SURFACE{$type} = 1;
+               if (scalar(@cnlist) eq 4) {
+                  $fname = rstname($cnlist[1], $type, "%s.%s.${ymd}_0000");
+                  my $ldas_rst_dir = "$cnlist[2]/$cnlist[1]/output/$cnlist[3]/rs/ens0000/Y${year}/M${month}/";
+                  $file = findinput($fname, $ldas_rst_dir);
+               }
+               elsif (scalar(@cnlist) eq 1) {
+                  $fname = rstname($expid, $type, "%s.%s.${ymd}_0000");
+                  $file  = findinput($fname);
+               }
+              if ($file) { $input_restarts{$type} = $file}
+              else  {
+                    die("File $file not found;");
+              }
+              next;
+            }
             if ($type eq "saltwater_internal_rst") {
                 $swFLG = 0 if $notfound{"openwater_internal_rst"};
                 $swFLG = 0 if $notfound{"seaicethermo_internal_rst"}
@@ -2906,7 +2922,8 @@ sub regrid_surface_rsts {
         $catch .= ".$tagID.$gridID" if $label;
 
         if ($mk_catchcn) {
-           $catchcnName = rstname($expid2, "catchcn${cnlist[0]}_internal_rst", $template2);
+           #$catchcnName = rstname($expid2, "catchcn${cnlist[0]}_internal_rst", $template2);
+           $catchcnName = rstname($expid2, "catchcn${cnlist[0]}_internal_rst", "%s.%s.${ymd}_${hr}z.nc4");
            $catchcnIN = "$InData_dir/$catchcnName";
            $catchcn = "$rstdir2/$catchcnName";
            $catchcn .= ".$tagID.$gridID" if $label;
@@ -3041,6 +3058,7 @@ sub rename_surface_rsts {
         }
         $newname = rstname($expid2, $type, "$outdir/$template2");
         $newname .= ".$tagID.$gridID" if $label;
+        if ($type eq "catchcn${cnlist[0]}_internal_rst" ){ $newname = rstname($expid2, $type, "$outdir/%s.%s.${ymd}_${hr}z.nc4")};
         move_("\n$newrst", $newname);
     }
 

--- a/GEOS_Util/post/regrid.pl
+++ b/GEOS_Util/post/regrid.pl
@@ -1584,12 +1584,12 @@ sub check_rst_files {
             if ($type eq "catchcn${cnlist[0]}_internal_rst") { 
                $SURFACE{$type} = 1;
                if (scalar(@cnlist) eq 4) {
-                  $fname = rstname($cnlist[1], $type, "%s.%s.${ymd}_0000");
+                  $fname = rstname($cnlist[1], $type, "%s.%s.${ymd}_${hr}00");
                   my $ldas_rst_dir = "$cnlist[2]/$cnlist[1]/output/$cnlist[3]/rs/ens0000/Y${year}/M${month}/";
                   $file = findinput($fname, $ldas_rst_dir);
                }
                elsif (scalar(@cnlist) eq 1) {
-                  $fname = rstname($expid, $type, "%s.%s.${ymd}_0000");
+                  $fname = rstname($expid, $type, "%s.%s.${ymd}_${hr}00");
                   $file  = findinput($fname);
                }
               if ($file) { $input_restarts{$type} = $file}

--- a/GEOS_Util/post/regrid.pl
+++ b/GEOS_Util/post/regrid.pl
@@ -1584,9 +1584,16 @@ sub check_rst_files {
             if ($type eq "catchcn${cnlist[0]}_internal_rst") { 
                $SURFACE{$type} = 1;
                if (scalar(@cnlist) eq 4) {
+                  # find GEOSldas file first
                   $fname = rstname($cnlist[1], $type, "%s.%s.${ymd}_${hr}00");
                   my $ldas_rst_dir = "$cnlist[2]/$cnlist[1]/output/$cnlist[3]/rs/ens0000/Y${year}/M${month}/";
                   $file = findinput($fname, $ldas_rst_dir);
+                  # find LDASsa file 
+                  unless ($file) {
+                     $fname = rstname($cnlist[1], $type, "%s.ens0000.%s.${ymd}_${hr}00z");
+                     $ldas_rst_dir = "$cnlist[2]/$cnlist[1]/output/$cnlist[3]/rs/ens0000/Y${year}/M${month}/";
+                     $file = findinput($fname, $ldas_rst_dir);
+                  }         
                }
                elsif (scalar(@cnlist) eq 1) {
                   $fname = rstname($expid, $type, "%s.%s.${ymd}_${hr}00");

--- a/GEOS_Util/post/regrid.pl
+++ b/GEOS_Util/post/regrid.pl
@@ -2824,7 +2824,7 @@ sub regrid_surface_rsts {
 
                 # use catch for catchcn, if needed. WJ note: use catch for cnclm40 only
                 #---------------------------------
-                if ($type eq "catchcnclm40_internal_rst") {
+                if ($type eq "catchcn${cnlist[0]}_internal_rst") {
                     $alt = "catch_internal_rst";
                     $src = $input_restarts{$alt};
                     if ($src) {
@@ -2851,6 +2851,12 @@ sub regrid_surface_rsts {
         symlinkinput($tile1, $InData_dir);
         symlinkinput($tile2, $OutData_dir);
     }
+
+    # link clsm directory to OutData
+    #-------------------------------
+    $clsm = dirname($tile2) ."/clsm";
+    $clsm = "$H2{bcsdir}/clsm" unless -d $clsm;
+    symlinkinput($clsm, $OutData_dir);
 
     # link rst directory to OutData
     #------------------------------
@@ -2915,12 +2921,6 @@ sub regrid_surface_rsts {
 
         move_("\n$catch", "$catchIN", $verbose)     if $mk_catch;
         move_("\n$catchcn", "$catchcnIN", $verbose) if $mk_catchcn;
-
-        # link clsm directory to OutData
-        #-------------------------------
-        $clsm = dirname($tile2) ."/clsm";
-        $clsm = "$H2{bcsdir}/clsm" unless -d $clsm;
-        symlinkinput($clsm, $OutData_dir);
 
         # catch and/or catchcn restart only during this pass
         #---------------------------------------------------


### PR DESCRIPTION
1) This regrid.pl depends on some mk_restart programs in GEOSgcm_GridComp. This is not desirable and needs further discussion to re-organize the codes. 
2) @gmao-jkolassa,  I don't know perl and don't know how to use regrid.pl but I made changes anyway.  So I really need help to test the program with this branch https://github.com/GEOS-ESM/GEOSgcm_GridComp/tree/feature/wjiang/jkolassa_cnclm45_mk_restart . I believe what we need for the command line is the CN_VERSION to be "clm40" or clm45"

