### PR TITLE
Fix for CICE4 segfault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed issue with CICE4 by compiling with old non-vectorized `Release` flags when compiling with Intel
+- Fixed issue with CICE4 by compiling with old non-vectorized `Release` flags when compiling with Intel. Requires ESMA_cmake v3.6.1
 
 ## [1.4.7] - 2021-10-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 
+## [1.4.8] - 2021-10-05
+
+### Fixed
+
+- Fixed issue with CICE4 by compiling with old non-vectorized `Release` flags when compiling with Intel
+
 ## [1.4.7] - 2021-10-04
 
 ### Added

--- a/LANL_Shared/CICE4/CMakeLists.txt
+++ b/LANL_Shared/CICE4/CMakeLists.txt
@@ -54,4 +54,11 @@ if (CMAKE_SYSTEM_NAME MATCHES Linux)
    target_compile_definitions(${this} PRIVATE LINUX)
 endif ()
 
+# It turns out the new vectorized Release flags for Intel cause a segfault
+# in CICE4. For now, we workaround this by restoring the old non-vectorized
+# flags here when building as Release
+if (CMAKE_Fortran_COMPILER_ID MATCHES Intel AND CMAKE_BUILD_TYPE MATCHES Release)
+  set (CMAKE_Fortran_FLAGS_RELEASE  "${GEOS_Fortran_FLAGS_NOVECT}")
+endif ()
+
 ecbuild_add_executable(TARGET makdep SOURCES bld/makdep.c)


### PR DESCRIPTION
This is a fix for a run-time segfault for CICE4. This needs ESMA_cmake v3.6.1 due to needing a new CMake variable.