### PR TITLE
Update CI to Baselibs 6.2.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   gfortran:
     docker:
-      - image: gmao/ubuntu20-geos-env-mkl:v6.2.7-openmpi_4.0.6-gcc_11.2.0
+      - image: gmao/ubuntu20-geos-env-mkl:v6.2.8-openmpi_4.0.6-gcc_11.2.0
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_AUTH_TOKEN
@@ -17,7 +17,7 @@ executors:
 
   ifort:
     docker:
-      - image: gmao/ubuntu20-geos-env:v6.2.7-intelmpi_2021.2.0-intel_2021.2.0
+      - image: gmao/ubuntu20-geos-env:v6.2.8-intelmpi_2021.2.0-intel_2021.2.0
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_AUTH_TOKEN

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated CI to use Baselibs 6.2.8
+
 ### Removed
 
 ## [1.4.10] - 2021-10-08


### PR DESCRIPTION
This PR updates the CI to use Baselibs 6.2.8. This is futureproofing for MAPL development which needs a newer version of gFTL that doesn't affect GEOS as a whole yet.

This is still zero-diff for GEOS.