### PR TITLE
Compress CircleCI Artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,14 @@ commands:
           command: |
             mpirun --version && << parameters.compiler >> --version && echo $BASEDIR && pwd && ls && echo "$(nproc)"
 
+  compress_artifacts:
+    description: "Compress artifacts"
+    steps:
+      - run:
+          name: "Compress artifacts"
+          command: |
+            gzip -9 /logfiles/*
+
   checkout_fixture:
     description: "Checkout fixture"
     parameters:
@@ -158,5 +166,6 @@ jobs:
           compiler: << parameters.compiler >>
       - buildinstall:
           repo: GEOSgcm
+      - compress_artifacts
       - store_artifacts:
           path: /logfiles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Compress CircleCI artifacts
+
 ### Fixed
 
 ### Removed


### PR DESCRIPTION
This PR compresses the CircleCI artifacts since CircleCI will soon charge for storage over a limit:

https://circleci.com/docs/2.0/persist-data/#storage

This is trivially zero-diff to the model as it only affects CI