### PR TITLE
Fix up changelog for 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Compress CircleCI artifacts
-- Updated CircleCI to use Orb
-
 ### Fixed
 
 ### Removed
+
+## [1.5.1] - 2022-02-04
+
+### Changed
+
+- Compress CircleCI artifacts
+- Updated CircleCI to use Orb
 
 ## [1.5.0] - 2021-12-16
 


### PR DESCRIPTION
I noticed that the changelog didn't have the 1.5.1 release. This fixes that up.