### PR TITLE
Minor CMake change for mod file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a minor CMake issue to keep all mod files in `build/include`
+
 ### Added
 
 ### Removed

--- a/GEOS_Util/post/CMakeLists.txt
+++ b/GEOS_Util/post/CMakeLists.txt
@@ -38,6 +38,7 @@ set_target_properties(stats.x PROPERTIES Fortran_MODULE_DIRECTORY ${include_${th
 
 ecbuild_add_executable (TARGET convert_aerosols.x SOURCES convert_aerosols.F)
 ecbuild_add_executable (TARGET 3CH_mpi.x SOURCES 3CH.F90)
+set_target_properties(3CH_mpi.x PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
 
 set (perlscripts
   ecmwf2geos.pl


### PR DESCRIPTION
This PR just puts the module file from `3CH.F90` into the `include/` directory. Minor tweak, but it makes Ninja happier and keeps the build dir clean. 