### PR TITLE
Allow for non-quad-precision systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix in stoch to allow systems without REAL128 (quad precision) to build
+
 ### Removed
 
 ## [1.5.4] - 2022-05-03
 
 ### Added
 
-- Added statsNx.rc for screen level variable fstats 
+- Added statsNx.rc for screen level variable fstats
 
 ### Changed
 

--- a/GMAO_stoch/mod_param.F90
+++ b/GMAO_stoch/mod_param.F90
@@ -6,13 +6,13 @@
 
     include 'mpif.h'
 
-!   ! Machine   ------------------------------------------------------! 
+!   ! Machine   ------------------------------------------------------!
     integer, parameter :: kind_evod = 8, kind_dbl_prec = 8, kind_io4 = 4
-    integer, parameter :: kind_real = 8, kind_integer = 4                     
-    integer, parameter :: kind_phys = selected_real_kind(13,60) 
-    integer, parameter :: kind_qdt_prec = selected_real_kind(30,90)
+    integer, parameter :: kind_real = 8, kind_integer = 4
+    integer, parameter :: kind_phys = max(kind_real,selected_real_kind(13,60))
+    integer, parameter :: kind_qdt_prec = max(kind_phys,selected_real_kind(30,90))
 
-!   ! Constants ------------------------------------------------------! 
+!   ! Constants ------------------------------------------------------!
     real(kind=kind_phys),parameter:: con_pi     =3.1415926535897931 ! pi
     real(kind=kind_phys),parameter:: con_rerth  =6.3712e+6 ! radius of earth (m)
 
@@ -40,8 +40,8 @@
     integer      :: ens_mem
     character*20 :: ens_nam
     real(kind=kind_evod), dimension(5) :: sppt,sppt_lscale,sppt_tau, &
-                                          skeb,skeb_lscale,skeb_tau 
-    real(kind=kind_evod)     :: sppt_sigtop1,sppt_sigtop2, & 
+                                          skeb,skeb_lscale,skeb_tau
+    real(kind=kind_evod)     :: sppt_sigtop1,sppt_sigtop2, &
                                 skeb_sigtop1,skeb_sigtop2
     real(kind=kind_evod)     :: skeb_diss_smooth
     integer,    dimension(5) :: skeb_vfilt


### PR DESCRIPTION
In testing GEOS on an M1 MacBook, it was found that GNU on M1 does not support quad-precision (aka REAL128). Stoch currently uses this in its kinds. So, what this PR does is back down quad precision code to double precision if not supported. If it is supported, then nothing changes.

I'll add @elakkraoui to the reviewers as, well, I think of her when I think of this code.