### PR TITLE
Update CMake in ADAS-only subdirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- More updates to CMake to more canonical CMake style (NetCDF, ESMF, etc.). These were missed in previous go-arounds as they are only built with ADAS.
+
 ### Removed
 
 ## [1.5.4] - 2022-05-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- More updates to CMake to more canonical CMake style (NetCDF, ESMF, etc.). These were missed in previous go-arounds as they are only built with ADAS.
+- More updates to CMake to more canonical CMake style (NetCDF, ESMF, etc.). These were missed in previous go-arounds as they are only built with ADAS. (Requires ESMA_cmake v3.15.1)
 
 ### Removed
 

--- a/GMAO_ncdiag/nc_diag_cat/CMakeLists.txt
+++ b/GMAO_ncdiag/nc_diag_cat/CMakeLists.txt
@@ -9,16 +9,12 @@ set (SRCS
 
 esma_add_library (${this}
   SRCS ${SRCS}
-  DEPENDENCIES nc_diag_write
-  INCLUDES ${INC_NETCDF}
+  DEPENDENCIES nc_diag_write NetCDF::NetCDF_Fortran
   )
 target_compile_definitions (${this} PRIVATE _REAL8_ ERROR_TRACEBACK QUIET)
 
 ecbuild_add_executable (TARGET test_nc_unlimdims.x SOURCES test_nc_unlimdims.F90)
-target_link_libraries (test_nc_unlimdims.x PUBLIC ${this} ${ESMF_LIBRARIES})
+target_link_libraries (test_nc_unlimdims.x PUBLIC ${this} esmf)
 
 ecbuild_add_executable (TARGET nc_diag_cat.x SOURCES nc_diag_cat.F90)
-target_link_libraries (nc_diag_cat.x PUBLIC ${this} ${ESMF_LIBRARIES})
-
-
-  
+target_link_libraries (nc_diag_cat.x PUBLIC ${this} esmf)

--- a/GMAO_ncdiag/nc_diag_read/CMakeLists.txt
+++ b/GMAO_ncdiag/nc_diag_read/CMakeLists.txt
@@ -7,8 +7,8 @@ set (SRCS
   )
 
 esma_add_library (${this}
-  SRCS ${SRCS}
-  INCLUDES ${INC_NETCDF}
+  SRCS ${SRCS} 
+  DEPENDENCIES NetCDF::NetCDF_Fortran
   )
 
 target_compile_definitions (${this} PRIVATE _REAL8_ ERROR_TRACEBACK)

--- a/GMAO_ncdiag/nc_diag_write/CMakeLists.txt
+++ b/GMAO_ncdiag/nc_diag_write/CMakeLists.txt
@@ -9,7 +9,7 @@ set (SRCS
 
 esma_add_library (${this}
   SRCS ${SRCS}
-  INCLUDES ${INC_NETCDF}
+  DEPENDENCIES NetCDF::NetCDF_Fortran
   )
 
 target_compile_definitions (${this} PRIVATE _REAL8_ ERROR_TRACEBACK ENABLE_ACTION_MSGS)

--- a/GMAO_ods/CMakeLists.txt
+++ b/GMAO_ods/CMakeLists.txt
@@ -43,24 +43,23 @@ endif ()
 
 esma_add_library (${this}
   SRCS ${MODSRC} ${ODSSRC}
-  DEPENDENCIES GMAO_mpeu GMAO_pilgrim
-  INCLUDES ${INC_NETCDF}
+  DEPENDENCIES GMAO_mpeu GMAO_pilgrim NetCDF::NetCDF_Fortran
   )
 
-ecbuild_add_executable (TARGET ods_scan.x   SOURCES ods_scan.f     LIBS ${this} ${NETCDF_LIBRARIES})
-ecbuild_add_executable (TARGET dconv2ods.x  SOURCES dconv2ods.f    LIBS ${this} ${NETCDF_LIBRARIES})
-ecbuild_add_executable (TARGET ods_blank.x  SOURCES ods_blank.f90  LIBS ${this} ${NETCDF_LIBRARIES})
-ecbuild_add_executable (TARGET ods_maker.x  SOURCES ods_maker.f90  LIBS ${this} ${NETCDF_LIBRARIES})
-ecbuild_add_executable (TARGET ods_sample.x SOURCES ods_sample.f   LIBS ${this} ${NETCDF_LIBRARIES})
-ecbuild_add_executable (TARGET ods_synX2Y.x SOURCES ods_synX2Y.f90 LIBS ${this} ${NETCDF_LIBRARIES})
-ecbuild_add_executable (TARGET ods_tally.x  SOURCES ods_tally.f90  LIBS ${this} ${NETCDF_LIBRARIES})
-ecbuild_add_executable (TARGET saber2ods.x  SOURCES saber2ods.f    LIBS ${this} ${NETCDF_LIBRARIES})
-ecbuild_add_executable (TARGET odslist      SOURCES odslist.f      LIBS ${this} ${NETCDF_LIBRARIES})
-ecbuild_add_executable (TARGET odsmatch     SOURCES odsmatch.f     LIBS ${this} ${NETCDF_LIBRARIES})
-ecbuild_add_executable (TARGET odsselect    SOURCES odsselect.f    LIBS ${this} ${NETCDF_LIBRARIES})
-ecbuild_add_executable (TARGET odsshuffle   SOURCES odsshuffle.f   LIBS ${this} ${NETCDF_LIBRARIES})
-ecbuild_add_executable (TARGET odsstats     SOURCES odsstats.f     LIBS ${this} ${NETCDF_LIBRARIES})
-ecbuild_add_executable (TARGET odsemean     SOURCES odsemean.f     LIBS ${this} ${NETCDF_LIBRARIES})
+ecbuild_add_executable (TARGET ods_scan.x   SOURCES ods_scan.f     LIBS ${this} NetCDF::NetCDF_Fortran)
+ecbuild_add_executable (TARGET dconv2ods.x  SOURCES dconv2ods.f    LIBS ${this} NetCDF::NetCDF_Fortran)
+ecbuild_add_executable (TARGET ods_blank.x  SOURCES ods_blank.f90  LIBS ${this} NetCDF::NetCDF_Fortran)
+ecbuild_add_executable (TARGET ods_maker.x  SOURCES ods_maker.f90  LIBS ${this} NetCDF::NetCDF_Fortran)
+ecbuild_add_executable (TARGET ods_sample.x SOURCES ods_sample.f   LIBS ${this} NetCDF::NetCDF_Fortran)
+ecbuild_add_executable (TARGET ods_synX2Y.x SOURCES ods_synX2Y.f90 LIBS ${this} NetCDF::NetCDF_Fortran)
+ecbuild_add_executable (TARGET ods_tally.x  SOURCES ods_tally.f90  LIBS ${this} NetCDF::NetCDF_Fortran)
+ecbuild_add_executable (TARGET saber2ods.x  SOURCES saber2ods.f    LIBS ${this} NetCDF::NetCDF_Fortran)
+ecbuild_add_executable (TARGET odslist      SOURCES odslist.f      LIBS ${this} NetCDF::NetCDF_Fortran)
+ecbuild_add_executable (TARGET odsmatch     SOURCES odsmatch.f     LIBS ${this} NetCDF::NetCDF_Fortran)
+ecbuild_add_executable (TARGET odsselect    SOURCES odsselect.f    LIBS ${this} NetCDF::NetCDF_Fortran)
+ecbuild_add_executable (TARGET odsshuffle   SOURCES odsshuffle.f   LIBS ${this} NetCDF::NetCDF_Fortran)
+ecbuild_add_executable (TARGET odsstats     SOURCES odsstats.f     LIBS ${this} NetCDF::NetCDF_Fortran)
+ecbuild_add_executable (TARGET odsemean     SOURCES odsemean.f     LIBS ${this} NetCDF::NetCDF_Fortran)
 
 set (targets_for_extra_flags
    ${this}
@@ -104,10 +103,10 @@ if (USE_F2PY)
    if (F2PY2_FOUND)
       esma_add_f2py2_module(pyods_
          SOURCES pyods_.F90
-         LIBRARIES GMAO_ods GMAO_mpeu ${NETCDF_LIBRARIES}
-         INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${BASEDIR}/lib ${include_${this}} ${INC_NETCDF}
+         LIBRARIES GMAO_ods GMAO_mpeu
+         INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${include_${this}}
          DESTINATION lib/Python/pyods
-         USE_MPI
+         USE_MPI USE_NETCDF
          )
       add_dependencies(pyods_ ${this})
    endif ()


### PR DESCRIPTION
This PR updates the CMake in some ADAS-only subdirs a la #254. 

Note that this technically requires ESMA_cmake v3.15.1 (https://github.com/GEOS-ESM/GEOSgcm/pull/418) though GEOSgcm builds will never notice that.