### PR TITLE
Bugfix/zhaobin74/#268 force symmetry tripole in subcycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - More updates to CMake to more canonical CMake style (NetCDF, ESMF, etc.). These were missed in previous go-arounds as they are only built with ADAS. (Requires ESMA_cmake v3.15.1)
 
+- Fixed a bug in CICE4 EVP dynamic code to force symmetry across the fold in every subcycle step
+
 ### Removed
 
 ## [1.5.4] - 2022-05-03
@@ -35,7 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a minor CMake issue to keep all mod files in `build/include`
-- Fixed a bug in CICE4 EVP dynamic code to force symmetry across teh fold in every subcycle step
 
 ## [1.5.3] - 2022-03-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a minor CMake issue to keep all mod files in `build/include`
+- Fixed a bug in CICE4 EVP dynamic code to force symmetry across teh fold in every subcycle step
 
 ## [1.5.3] - 2022-03-18
 

--- a/LANL_Shared/CICE4/source/ice_dyn_evp.F90
+++ b/LANL_Shared/CICE4/source/ice_dyn_evp.F90
@@ -620,38 +620,39 @@
 #endif
          enddo        
 #endif
+        ! Force symmetry across the tripole seam
+        ! Bin Zhao: move this operation in the subcycle loop to eliminate
+        ! spurious ice ridging problem seen on the fold of some tripolar grids 
+        if (trim(grid_type) == 'tripole') then
+
+           call ice_HaloUpdate_stress(stressp_1, stressp_3, halo_info, &
+                                field_loc_center,  field_type_scalar)
+           call ice_HaloUpdate_stress(stressp_3, stressp_1, halo_info, &
+                                field_loc_center,  field_type_scalar)
+           call ice_HaloUpdate_stress(stressp_2, stressp_4, halo_info, &
+                                field_loc_center,  field_type_scalar)
+           call ice_HaloUpdate_stress(stressp_4, stressp_2, halo_info, &
+                                field_loc_center,  field_type_scalar)
+
+           call ice_HaloUpdate_stress(stressm_1, stressm_3, halo_info, &
+                                field_loc_center,  field_type_scalar)
+           call ice_HaloUpdate_stress(stressm_3, stressm_1, halo_info, &
+                                field_loc_center,  field_type_scalar)
+           call ice_HaloUpdate_stress(stressm_2, stressm_4, halo_info, &
+                                field_loc_center,  field_type_scalar)
+           call ice_HaloUpdate_stress(stressm_4, stressm_2, halo_info, &
+                                field_loc_center,  field_type_scalar)
+
+           call ice_HaloUpdate_stress(stress12_1, stress12_3, halo_info, &
+                                field_loc_center,  field_type_scalar)
+           call ice_HaloUpdate_stress(stress12_3, stress12_1, halo_info, &
+                                field_loc_center,  field_type_scalar)
+           call ice_HaloUpdate_stress(stress12_2, stress12_4, halo_info, &
+                                field_loc_center,  field_type_scalar)
+           call ice_HaloUpdate_stress(stress12_4, stress12_2, halo_info, &
+                                field_loc_center,  field_type_scalar)
+        endif   ! tripole
       enddo                     ! subcycling
-
-      ! Force symmetry across the tripole seam
-      if (trim(grid_type) == 'tripole') then
-
-         call ice_HaloUpdate_stress(stressp_1, stressp_3, halo_info, &
-                              field_loc_center,  field_type_scalar)
-         call ice_HaloUpdate_stress(stressp_3, stressp_1, halo_info, &
-                              field_loc_center,  field_type_scalar)
-         call ice_HaloUpdate_stress(stressp_2, stressp_4, halo_info, &
-                              field_loc_center,  field_type_scalar)
-         call ice_HaloUpdate_stress(stressp_4, stressp_2, halo_info, &
-                              field_loc_center,  field_type_scalar)
-
-         call ice_HaloUpdate_stress(stressm_1, stressm_3, halo_info, &
-                              field_loc_center,  field_type_scalar)
-         call ice_HaloUpdate_stress(stressm_3, stressm_1, halo_info, &
-                              field_loc_center,  field_type_scalar)
-         call ice_HaloUpdate_stress(stressm_2, stressm_4, halo_info, &
-                              field_loc_center,  field_type_scalar)
-         call ice_HaloUpdate_stress(stressm_4, stressm_2, halo_info, &
-                              field_loc_center,  field_type_scalar)
-
-         call ice_HaloUpdate_stress(stress12_1, stress12_3, halo_info, &
-                              field_loc_center,  field_type_scalar)
-         call ice_HaloUpdate_stress(stress12_3, stress12_1, halo_info, &
-                              field_loc_center,  field_type_scalar)
-         call ice_HaloUpdate_stress(stress12_2, stress12_4, halo_info, &
-                              field_loc_center,  field_type_scalar)
-         call ice_HaloUpdate_stress(stress12_4, stress12_2, halo_info, &
-                              field_loc_center,  field_type_scalar)
-      endif   ! tripole
 
       !-----------------------------------------------------------------
       ! ice-ocean stress


### PR DESCRIPTION
This PR fixed issue #268.

- The block of code enforcing stress symmetry across the tripolar fold is moved inside the EVP subcycling loop.
- This change fixed the spurious ice ridging problem as seen with some MOM6 OM4 grids.
- This PR is 0-diff in uncoupled mode and fixes a bug in coupled mode.