### PR TITLE
Update CircleCI to use Baselibs 7.5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,9 @@
 version: 2.1
 
+# Anchors to prevent forgetting to update a version
+baselibs_version: &baselibs_version v7.5.0
+bcs_version: &bcs_version v10.22.3
+
 orbs:
   ci: geos-esm/circleci-tools@1
 
@@ -14,6 +18,7 @@ workflows:
           matrix:
             parameters:
               compiler: [gfortran, ifort]
+          baselibs_version: *baselibs_version
           repo: GEOSgcm
           checkout_fixture: true
           mepodevelop: true


### PR DESCRIPTION
This PR updates the CI here to match GEOSgcm now that https://github.com/GEOS-ESM/GEOSgcm/pull/428 has merged into GEOSgcm `main`
