### PR TITLE
Robust check for history's monthly attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Implemented a more robust check to test if a history's monthly attribute is 1 (on) and not commented out.
 - More updates to CMake to more canonical CMake style (NetCDF, ESMF, etc.). These were missed in previous go-arounds as they are only built with ADAS. (Requires ESMA_cmake v3.15.1)
 - Fixed setting of `ks` in `m_set_eta.F90` to be based on `bk`
 

--- a/GEOS_Util/post/gcmpost.script
+++ b/GEOS_Util/post/gcmpost.script
@@ -475,7 +475,7 @@ end
      set numlocs  = ''
      @    nstream = 0
      foreach collection (  $collections )
-          set monthly_attribute = `grep -i $collection.monthly: $HISTORYRC`
+          set monthly_attribute = `grep -i "^[\t ]*$collection.monthly:[\t ]*1" $HISTORYRC`
      @    nstream =                   $nstream  + 1
      @  date_node = $expdots + $ndots[$nstream] + 3
 
@@ -569,7 +569,7 @@ set monthly_collections = "FALSE"
 @ m      = 1
 @ begloc = 1
 foreach collection ( $collections )
-        set   monthly_attribute = `grep -i $collection.monthly: $HISTORYRC`
+        set   monthly_attribute = `grep -i "^[\t ]*$collection.monthly:[\t ]*1" $HISTORYRC`
         if( ${monthly_collections} == "FALSE" & ${#monthly_attribute} != 0 ) set monthly_collections = "TRUE"
 
       @ endloc = $begloc + $numdates[$m] - 1
@@ -730,7 +730,7 @@ if( $AGCM_IM >= 1152 | ($AGCM_IM >= 360 & $CUBE == TRUE ) ) set HIRES = TRUE
 @ begloc  = 1
 @ nstream = 0
 foreach collection ( $collections )
-     set monthly_attribute = `grep -i $collection.monthly: $HISTORYRC`
+     set monthly_attribute = `grep -i "^[\t ]*$collection.monthly:[\t ]*1" $HISTORYRC`
    @ nstream   =                   $nstream  + 1
    @ date_node = $expdots + $ndots[$nstream] + 3
    @ endloc = $begloc + $numdates[$m] - 1
@@ -835,9 +835,9 @@ foreach collection ( $collections )
                if( ${#monthly_attribute} != 0 ) @ monthly_date_node  = $date_node
 
                if( ${#monthly_attribute} == 0 ) then
-               set locals = `/bin/ls -1 | grep ${expid}.${collection} | grep  monthly | grep -v diurnal`
+                   set locals = `/bin/ls -1 | grep "${expid}.${collection}.*${ext}"   | grep  monthly | grep -v diurnal`
                else
-                   set locals = `/bin/ls -1 | grep ${expid}.${collection} | grep -v diurnal`
+                   set locals = `/bin/ls -1 | grep "${expid}.${collection}.[0-9]\{6\}01_0000z.${ext}" | grep -v diurnal`
                endif
 
                echo "Archiving Monthlies for Collection: $collection for Date: $date"
@@ -857,8 +857,7 @@ foreach collection ( $collections )
                   if( ${#monthly_attribute} == 0 ) then
                       $cpvar $local $SOURCE/$collection
                   else
-                      set yearmonth = `echo $local | sed -n "s|${expid}.${collection}.\([0-9]\{6\}\).*|\1|p"`
-                      $cpvar $local $SOURCE/$collection/${expid}.${collection}.monthly.${yearmonth}.${ext}
+                      $cpvar $local $SOURCE/$collection/${expid}.${collection}.monthly.${year}${month}.${ext}
                   endif
 
                   echo "if( -e $local ) then"                                          >> $archfile
@@ -1041,7 +1040,7 @@ wait
 
 @ nstream = 0
 foreach collection ( $collections )
-     set monthly_attribute = `grep -i $collection.monthly: $HISTORYRC`
+     set monthly_attribute = `grep -i "^[\t ]*$collection.monthly:[\t ]*1" $HISTORYRC`
     @ nstream   =                   $nstream  + 1
 
      if( ( ($MOVEFILES != "TRUE") & ${#monthly_attribute} == 0 ) | \
@@ -1267,7 +1266,7 @@ if( $PLOTS[1] == "NULL" ) then
                                       lockfile LOCKFILE
 @ count = 0
 foreach stream ($streams)
-    set monthly_attribute = `grep -i $collection.monthly: $HISTORYRC`
+    set monthly_attribute = `grep -i "^[\t ]*$collection.monthly:[\t ]*1" $HISTORYRC`
     echo Checking stream: $stream for date: $date
     if( ${#monthly_attribute} == 0 ) then
         set checkstream = `/bin/ls -1 $SOURCE/$stream/$expid.$stream.monthly.${date}* | grep -v clim`


### PR DESCRIPTION
Implemented a more robust check to test if a history's monthly attribute is 1 (on) and not commented out.