### PR TITLE
Fix in ncdiag for Intel 2022.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Add `target` attribute to variables in `nc_diag_cat`. Needed to build with Intel 2022.1
+
 ### Removed
 
 ## [1.5.6] - 2022-07-22

--- a/GMAO_ncdiag/nc_diag_cat/netcdf_unlimdims.F90
+++ b/GMAO_ncdiag/nc_diag_cat/netcdf_unlimdims.F90
@@ -21,8 +21,8 @@ module netcdf_unlimdims
         ! pf = polyfill
         integer(c_int) function pf_nf90_inq_unlimdims(ncid, num_unlim_dims, unlim_dims)
             integer(c_int), intent(in)            :: ncid
-            integer(c_int), intent(inout)         :: num_unlim_dims
-            integer(c_int), intent(out), optional :: unlim_dims(:)
+            integer(c_int), target, intent(inout)         :: num_unlim_dims
+            integer(c_int), target, intent(out), optional :: unlim_dims(:)
             
             integer :: i
             


### PR DESCRIPTION
In testing Intel 2022.1 in MAPL, it was found that the GEOSadas would not build. The issue was in `nc_diag_cat`:
```
/root/project/GEOSadas/src/Shared/@GMAO_Shared/GMAO_ncdiag/nc_diag_cat/netcdf_unlimdims.F90(31): error #9022: The argument to C_LOC must be a variable with the POINTER or TARGET attribute.   [NUM_UNLIM_DIMS]
                pf_nf90_inq_unlimdims = nc_inq_unlimdims(ncid, c_loc(num_unlim_dims), c_loc(unlim_dims))
---------------------------------------------------------------------^
/root/project/GEOSadas/src/Shared/@GMAO_Shared/GMAO_ncdiag/nc_diag_cat/netcdf_unlimdims.F90(31): error #9022: The argument to C_LOC must be a variable with the POINTER or TARGET attribute.   [UNLIM_DIMS]
                pf_nf90_inq_unlimdims = nc_inq_unlimdims(ncid, c_loc(num_unlim_dims), c_loc(unlim_dims))
--------------------------------------------------------------------------------------------^
/root/project/GEOSadas/src/Shared/@GMAO_Shared/GMAO_ncdiag/nc_diag_cat/netcdf_unlimdims.F90(37): error #9022: The argument to C_LOC must be a variable with the POINTER or TARGET attribute.   [NUM_UNLIM_DIMS]
                pf_nf90_inq_unlimdims = nc_inq_unlimdims(ncid, c_loc(num_unlim_dims), c_null_ptr)
---------------------------------------------------------------------^

```
The fix is easy. The code in `nc_diag_cat` is:

https://github.com/GEOS-ESM/GMAO_Shared/blob/ee16c4590416841de72c1eb130519de5ea3b9768/GMAO_ncdiag/nc_diag_cat/netcdf_unlimdims.F90#L22-L25

but if we look at `nc_diag_read`:

https://github.com/GEOS-ESM/GMAO_Shared/blob/ee16c4590416841de72c1eb130519de5ea3b9768/GMAO_ncdiag/nc_diag_read/netcdf_unlimdims.F90#L22-L25

So we add `target` exactly as in `read`. And as it works there, it'll work here.

Note that the GCM doesn't even use this code.