### PR TITLE
Add S2Sv3 to MOM6 test. Add YAML validator

### DIFF
--- a/.github/workflows/changelog-enforcer.yml
+++ b/.github/workflows/changelog-enforcer.yml
@@ -4,7 +4,7 @@ on:
       types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 jobs:
-  # Enforces the update of a changelog file on every pull request 
+  # Enforces the update of a changelog file on every pull request
   changelog:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/validate_yaml_files.yml
+++ b/.github/workflows/validate_yaml_files.yml
@@ -1,0 +1,31 @@
+---
+
+# Based on code from https://github.com/marketplace/actions/yaml-lint
+
+name: Yaml Lint
+
+on:
+  pull_request:
+      types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+# This validation is equivalent to running on the command line:
+#   yamllint -d relaxed --no-warnings
+# and is controlled by the .yamllint.yml file
+jobs:
+  validate-YAML:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - id: yaml-lint
+        name: yaml-lint
+        uses: ibiqlik/action-yamllint@v3
+        with:
+          no_warnings: true
+          format: colored
+          config_file: .yamllint.yml
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: yamllint-logfile
+          path: ${{ steps.yaml-lint.outputs.logfile }}

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,29 @@
+---
+
+extends: default
+
+rules:
+  braces:
+    level: warning
+    max-spaces-inside: 1
+  brackets:
+    level: warning
+    max-spaces-inside: 1
+  colons:
+    level: warning
+  commas:
+    level: warning
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    level: warning
+  hyphens:
+    level: warning
+  indentation:
+    level: warning
+    indent-sequences: consistent
+  line-length:
+    level: warning
+    allow-non-breakable-inline-mappings: true
+  truthy: disable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Generated command line to run the program
-- changed the location of the temporary folder for remap_restarts MERRA-2 case 
+- changed the location of the temporary folder for remap_restarts MERRA-2 case
 - Added new remap tests
   - amip_c180Toc90
   - c180Toc360
   - c360Toc24
-  - s2sToc12MOM6
+  - s2sv3Toc12MOM6
 
 ### Fixed
 
@@ -54,7 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added statsNx.rc for screen level variable fstats 
+- Added statsNx.rc for screen level variable fstats
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add YAML validator
+
 ### Changed
 
 - Generated command line to run the program
 - changed the location of the temporary folder for remap_restarts MERRA-2 case 
+- Added new remap tests
+  - amip_c180Toc90
+  - c180Toc360
+  - c360Toc24
+  - s2sToc12MOM6
 
 ### Fixed
 

--- a/GEOS_Util/post/remap_restart/remap_params.tpl
+++ b/GEOS_Util/post/remap_restart/remap_params.tpl
@@ -1,7 +1,7 @@
 #
 # This template file can be filled with questionary or manually
-# 
-# 
+#
+#
 
 input:
   air:
@@ -9,7 +9,7 @@ input:
     hydrostatic: 0
   shared:
     MERRA-2: false
-    agrid: 
+    agrid:
     bcs_dir:
     expid:
     ogrid:
@@ -20,14 +20,14 @@ input:
     wemin:
     # it supports three models: catch, catchcnclm40, catchcnclm45
     catch_model: null
-    # if catch_tilefile is null, it searches bcs_dir     
+    # if catch_tilefile is null, it searches bcs_dir
     catch_tilefile: null
 output:
   shared:
     agrid:
-    bcs_dir: 
-    expid: 
-    ogrid: 
+    bcs_dir:
+    expid:
+    ogrid:
     out_dir:
   air:
     # remap upper air or not
@@ -41,7 +41,7 @@ output:
     remap_water: true
     # remap catch(cn)
     remap_catch: true
-    # if catch_tilefile is null, it searches bcs_dir     
+    # if catch_tilefile is null, it searches bcs_dir
     catch_tilefile: null
   analysis:
     bkg: true
@@ -49,6 +49,6 @@ output:
     lcv: false
 
 slurm:
-  account: 
-  qos: 
-  constraint: 
+  account:
+  qos:
+  constraint:

--- a/GEOS_Util/post/remap_restart/remap_utils.py
+++ b/GEOS_Util/post/remap_restart/remap_utils.py
@@ -52,9 +52,9 @@ def write_cmd(config) :
 
    flat_dict = flatten_nested(config)
 
-   k = 1   
+   k = 1
    for key, value in flat_dict.items():
-     if isinstance(value, int) or isinstance(value, float) :   value = str(value)
+     if isinstance(value, int) or isinstance(value, float) or isinstance(value, bool) or isinstance(value, type(None)): value = str(value)
      if k == 1:
        cmd = cmd + 'set FLAT_YAML="' + key+"="+ value+ '"\n'
      else:
@@ -111,7 +111,7 @@ def merra2_expid(config):
    config['expid'] = expid
 
    return config
- 
+
 if __name__ == '__main__' :
    config = yaml_to_config('c24Toc12.yaml')
    print_config(config)

--- a/GEOS_Util/post/tests/c180Toc360.yaml
+++ b/GEOS_Util/post/tests/c180Toc360.yaml
@@ -1,7 +1,7 @@
 #
 # This template file can be filled with questionary or manually
-# 
-# 
+#
+#
 
 input:
   air:
@@ -13,7 +13,7 @@ input:
     bcs_dir: /discover/nobackup/ltakacs/bcs/Icarus-NLv3/Icarus-NLv3_MERRA-2//CF0180x6C_DE1440xPE0720/
     expid: Jason-3_4_NL_REAMIP_MERRA2_C180
     ogrid: 1440X720
-    rst_dir: /discover/nobackup/projects/gmao/SIteam/Remapping_Test_Cases/c180Toc360/inputs/ 
+    rst_dir: /discover/nobackup/projects/gmao/SIteam/Remapping_Test_Cases/c180Toc360/inputs/
     yyyymmddhh: '1985050921'
   surface:
     zoom: '2'

--- a/GEOS_Util/post/tests/c24Toc12.yaml
+++ b/GEOS_Util/post/tests/c24Toc12.yaml
@@ -20,7 +20,7 @@ input:
     wemin: '13'
     # it supports three models: catch, catchcnclm40, catchcnclm45
     catch_model: catch
-
+    catch_tilefile: null
 output:
   shared:
     agrid: C12
@@ -29,14 +29,18 @@ output:
     ogrid: 360X180
     out_dir: $NOBACKUP/REMAP_TESTS/c24Toc12/
   air:
+    # remap upper air or not
     remap: true
     nlevel: '72'
   surface:
     split_saltwater: true
     surflay: 50.0
     wemin: '13'
+    # remap lake, saltwater, landicet
     remap_water: true
+    # remap catch(cn)
     remap_catch: true
+    catch_tilefile: null
   analysis:
     bkg: false
     aqua: true

--- a/GEOS_Util/post/tests/c24Toc12.yaml
+++ b/GEOS_Util/post/tests/c24Toc12.yaml
@@ -1,7 +1,7 @@
 #
 # This template file can be filled with questionary or manually
-# 
-# 
+#
+#
 
 input:
   air:

--- a/GEOS_Util/post/tests/c360Toc24.yaml
+++ b/GEOS_Util/post/tests/c360Toc24.yaml
@@ -1,7 +1,7 @@
 #
 # This template file can be filled with questionary or manually
-# 
-# 
+#
+#
 
 input:
   air:
@@ -13,7 +13,7 @@ input:
     bcs_dir: /discover/nobackup/projects/gmao/share/gmao_ops/fvInput/g5gcm/bcs/Icarus-NLv3/Icarus-NLv3_Ostia//CF0360x6C_CF0360x6C/
     expid: x0046a
     ogrid: C360
-    rst_dir: /discover/nobackup/projects/gmao/SIteam/Remapping_Test_Cases/c360Toc24/inputs 
+    rst_dir: /discover/nobackup/projects/gmao/SIteam/Remapping_Test_Cases/c360Toc24/inputs
     yyyymmddhh: '2022010121'
   surface:
     zoom: '4'
@@ -27,7 +27,7 @@ output:
     bcs_dir: /discover/nobackup/ltakacs/bcs/Icarus-NLv3/Icarus-NLv3_Reynolds//CF0024x6C_DE0360xPE0180/
     expid: C24c_x0046a
     ogrid: 360X180
-    out_dir: $NOBACKUP/REMAP_TESTS/c360Toc24/ 
+    out_dir: $NOBACKUP/REMAP_TESTS/c360Toc24/
   air:
     # remap upper air or not
     remap: true

--- a/GEOS_Util/post/tests/f522Toc360.yaml
+++ b/GEOS_Util/post/tests/f522Toc360.yaml
@@ -35,7 +35,6 @@ output:
     surflay: 50.0
     wemin: '13'
     remap_catch: true
-    catch_tilefile: null
     remap_water: true
     catch_tilefile: null
   analysis:

--- a/GEOS_Util/post/tests/f522Toc360.yaml
+++ b/GEOS_Util/post/tests/f522Toc360.yaml
@@ -19,7 +19,7 @@ input:
     zoom: '8'
     wemin: '26'
     catch_model: catch
-
+    catch_tilefile: null
 output:
   shared:
     agrid: C360
@@ -35,6 +35,7 @@ output:
     surflay: 50.0
     wemin: '13'
     remap_catch: true
+    catch_tilefile: null
     remap_water: true
   analysis:
     bkg: true

--- a/GEOS_Util/post/tests/f522Toc360.yaml
+++ b/GEOS_Util/post/tests/f522Toc360.yaml
@@ -1,7 +1,7 @@
 #
 # This template file can be filled with questionary or manually
-# 
-# 
+#
+#
 
 input:
   air:
@@ -13,7 +13,7 @@ input:
     bcs_dir: /discover/nobackup/projects/gmao/share/gmao_ops/fvInput/g5gcm/bcs/Icarus_Updated/Icarus_Ostia//CF0720x6C_CF0720x6C/
     expid: f522_fp
     ogrid: C720
-    rst_dir: /discover/nobackup/projects/gmao/SIteam/Remapping_Test_Cases/f522Toc360/inputs/ 
+    rst_dir: /discover/nobackup/projects/gmao/SIteam/Remapping_Test_Cases/f522Toc360/inputs/
     yyyymmddhh: '2019061421'
   surface:
     zoom: '8'

--- a/GEOS_Util/post/tests/s2sToc12MOM6.yaml
+++ b/GEOS_Util/post/tests/s2sToc12MOM6.yaml
@@ -19,7 +19,7 @@ input:
     wemin: '26'
     # it supports three models: catch, catchcnclm40, catchcnclm45
     catch_model: catch
-
+    catch_tilefile: null
 output:
   shared:
     agrid: C12
@@ -39,6 +39,7 @@ output:
     remap_water: true
     # remap catch(cn)
     remap_catch: true
+    catch_tilefile: null
   analysis:
     bkg: false
     aqua: true

--- a/GEOS_Util/post/tests/s2sToc12MOM6.yaml
+++ b/GEOS_Util/post/tests/s2sToc12MOM6.yaml
@@ -8,6 +8,7 @@ input:
     drymass: 1
     hydrostatic: 0
   shared:
+    MERRA-2: false
     agrid: C180
     bcs_dir: /discover/nobackup/projects/gmao/ssd/aogcm/atmosphere_bcs/Ganymed/MOM5//CF0180x6C_TM0720xTM0410/
     expid: S2S-2_1_ANA_001

--- a/GEOS_Util/post/tests/s2sToc12MOM6.yaml
+++ b/GEOS_Util/post/tests/s2sToc12MOM6.yaml
@@ -8,26 +8,25 @@ input:
     drymass: 1
     hydrostatic: 0
   shared:
-    MERRA-2: false
     agrid: C180
-    bcs_dir: /discover/nobackup/ltakacs/bcs/Icarus-NLv3/Icarus-NLv3_MERRA-2//CF0180x6C_DE1440xPE0720/
-    expid: JM_v10.22.2_L072_C180_AMIP
-    ogrid: 1440X720
-    rst_dir: /discover/nobackup/projects/gmao/SIteam/Remapping_Test_Cases/amip_c180Toc90/inputs/
-    yyyymmddhh: '1990062621'
+    bcs_dir: /discover/nobackup/projects/gmao/ssd/aogcm/atmosphere_bcs/Ganymed/MOM5//CF0180x6C_TM0720xTM0410/
+    expid: S2S-2_1_ANA_001
+    ogrid: 720X410
+    rst_dir: /discover/nobackup/projects/gmao/SIteam/Remapping_Test_Cases/s2sToc12MOM6/inputs
+    yyyymmddhh: '2021041600'
   surface:
     zoom: '2'
-    wemin: '13'
+    wemin: '26'
     # it supports three models: catch, catchcnclm40, catchcnclm45
     catch_model: catch
-    catch_tilefile: null
+
 output:
   shared:
-    agrid: C90
-    bcs_dir: /discover/nobackup/ltakacs/bcs/Icarus-NLv3/Icarus-NLv3_Ostia//CF0090x6C_CF0090x6C/
-    expid: C90CS_JM_v10.22.2_L072_C180_AMIP
-    ogrid: C90
-    out_dir: $NOBACKUP/REMAP_TESTS/amip_c180Toc90/
+    agrid: C12
+    bcs_dir: /discover/nobackup/projects/gmao/ssd/aogcm/atmosphere_bcs/Icarus-NLv3/MOM6//CF0012x6C_TM0072xTM0036/
+    expid: c12-MOM6
+    ogrid: 72X36
+    out_dir: $NOBACKUP/REMAP_TESTS/s2sToc12MOM6/
   air:
     # remap upper air or not
     remap: true
@@ -40,7 +39,6 @@ output:
     remap_water: true
     # remap catch(cn)
     remap_catch: true
-    catch_tilefile: null
   analysis:
     bkg: false
     aqua: true
@@ -49,4 +47,4 @@ output:
 slurm:
   account: g0620
   qos: debug
-  constraint: sky
+  constraint: cas

--- a/GEOS_Util/post/tests/s2sv3Toc12MOM6.yaml
+++ b/GEOS_Util/post/tests/s2sv3Toc12MOM6.yaml
@@ -10,24 +10,25 @@ input:
   shared:
     MERRA-2: false
     agrid: C180
-    bcs_dir: /discover/nobackup/projects/gmao/ssd/aogcm/atmosphere_bcs/Ganymed/MOM5//CF0180x6C_TM0720xTM0410/
-    expid: S2S-2_1_ANA_001
-    ogrid: 720X410
-    rst_dir: /discover/nobackup/projects/gmao/SIteam/Remapping_Test_Cases/s2sToc12MOM6/inputs
-    yyyymmddhh: '2021041600'
+    bcs_dir: /discover/nobackup/projects/gmao/ssd/aogcm/atmosphere_bcs/Icarus/MOM5//CF0180x6C_TM1440xTM1080/
+    expid: M2OCEAN_S2SV3
+    ogrid: 1440X1080
+    rst_dir: /discover/nobackup/projects/gmao/SIteam/Remapping_Test_Cases/s2sv3Toc12MOM6/inputs
+    yyyymmddhh: '1982010100'
   surface:
     zoom: '2'
     wemin: '26'
     # it supports three models: catch, catchcnclm40, catchcnclm45
     catch_model: catch
-    catch_tilefile: null
+    # if catch_tilefile is null, it searches bcs_dir
+    catch_tilefile:
 output:
   shared:
     agrid: C12
     bcs_dir: /discover/nobackup/projects/gmao/ssd/aogcm/atmosphere_bcs/Icarus-NLv3/MOM6//CF0012x6C_TM0072xTM0036/
-    expid: c12-MOM6
+    expid: C12-MOM6-from-S2Sv3
     ogrid: 72X36
-    out_dir: $NOBACKUP/REMAP_TESTS/s2sToc12MOM6/
+    out_dir: $NOBACKUP/REMAP_TESTS/s2sv3Toc12MOM6/
   air:
     # remap upper air or not
     remap: true
@@ -40,7 +41,8 @@ output:
     remap_water: true
     # remap catch(cn)
     remap_catch: true
-    catch_tilefile: null
+    # if catch_tilefile is null, it searches bcs_dir
+    catch_tilefile:
   analysis:
     bkg: false
     aqua: true

--- a/GEOS_Util/post/tests/test_remap_cases.yaml
+++ b/GEOS_Util/post/tests/test_remap_cases.yaml
@@ -13,6 +13,6 @@ c180Toc360:
 c360Toc24:
   base_line: '/discover/nobackup/projects/gmao/SIteam/Remapping_Test_Cases/c360Toc24/baseline/'
   config: 'c360Toc24.yaml'
-s2sToc12MOM6:
-  base_line: '/discover/nobackup/projects/gmao/SIteam/Remapping_Test_Cases/s2sToc12MOM6/baseline/'
-  config: 's2sToc12MOM6.yaml'
+s2sv3Toc12MOM6:
+  base_line: '/discover/nobackup/projects/gmao/SIteam/Remapping_Test_Cases/s2sv3Toc12MOM6/baseline/'
+  config: 's2sv3Toc12MOM6.yaml'

--- a/GEOS_Util/post/tests/test_remap_cases.yaml
+++ b/GEOS_Util/post/tests/test_remap_cases.yaml
@@ -6,11 +6,13 @@ f522Toc360:
   config: 'f522Toc360.yaml'
 amip_c180Toc90:
   base_line: '/discover/nobackup/projects/gmao/SIteam/Remapping_Test_Cases/amip_c180Toc90/baseline/'
-  config: 'amip_c180Toc90.yaml' 
+  config: 'amip_c180Toc90.yaml'
 c180Toc360:
   base_line: '/discover/nobackup/projects/gmao/SIteam/Remapping_Test_Cases/c180Toc360/baseline/'
   config: 'c180Toc360.yaml'
 c360Toc24:
   base_line: '/discover/nobackup/projects/gmao/SIteam/Remapping_Test_Cases/c360Toc24/baseline/'
   config: 'c360Toc24.yaml'
-
+s2sToc12MOM6:
+  base_line: '/discover/nobackup/projects/gmao/SIteam/Remapping_Test_Cases/s2sToc12MOM6/baseline/'
+  config: 's2sToc12MOM6.yaml'


### PR DESCRIPTION
This PR adds an S2Sv3-MOM5 to C12-MOM6 test case to the remapping tests. It also has some fixes from @weiyuan-jiang while debugging other issues I found/created. 😄 

It also adds a YAML validator and cleans up the existing YAML files to pass.