### PR TITLE
Make GMAO_etc depend on GMAO_perllib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Add a dependency on GMAO_perllib in GMAO_etc
+
 ### Removed
 
 ## [1.6.1] - 2022-09-22

--- a/GMAO_etc/CMakeLists.txt
+++ b/GMAO_etc/CMakeLists.txt
@@ -1,3 +1,11 @@
+esma_set_this()
+
+# Add a dummy custom target because GMAO_etc depends
+# on Perl modules in GMAO_perllib
+
+add_custom_target(${this} ALL)
+add_dependencies(${this} GMAO_perllib)
+
 set (CMAKE_Fortran_FLAGS_RELEASE "-O3 ${GEOS_Fortran_Release_FPE_Flags} ${ALIGNCOM}")
 
 ecbuild_add_executable (

--- a/GMAO_perllib/CMakeLists.txt
+++ b/GMAO_perllib/CMakeLists.txt
@@ -1,3 +1,10 @@
+esma_set_this()
+
+# add a dummy target so that GMAO_etc can depend
+# on GMAO_perllib
+
+add_custom_target(${this} ALL)
+
 set(perldirs
    ESMA
    GrADS


### PR DESCRIPTION
Testing with @rtodling found that the GMAO_Shared CMake doesn't know that GMAO_etc depends on Perl modules in GMAO_perllib, e.g., `GMAO_etc/Manipulate_time.pm` depends on `GMAO_perllib/Time/JulianDay.pm`.

So we add some dummy CMake targets so that we can express this dependency.