### PR TITLE
Fix issue with MERRA2 remapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix an issue with `remap_restarts.py` for post 2011 regridding from MERRA2
+
 ### Removed
 
 ## [1.6.3] - 2022-11-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,21 +11,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+### Fixed
+
+### Removed
+
+## [1.6.3] - 2022-12-07
+
+### Changed
+
 - Moved to GitHub Actions for label enforcement
 - Updated CircleCI to Baselibs 7.7.0
 - Set default data ocean to be `CS` at C90+ resolution in `remap_restarts.py`
 
 ### Fixed
 
-- Fix an issue with `remap_restarts.py` for post 2011 regridding from MERRA2
-
-### Removed
-
-## [1.6.3] - 2022-11-22
-
-### Fixed
-
 - Fix an issue with `regrid.pl` and `remap_restarts.py` regridding from MERRA-2 from 2021-06 to 2021-09
+- Fix an issue with `remap_restarts.py` for post 2011 regridding from MERRA2
 
 ## [1.6.2] - 2022-11-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Moved to GitHub Actions for label enforcement
 - Updated CircleCI to Baselibs 7.7.0
+- Set default data ocean to be `CS` at C90+ resolution in `remap_restarts.py`
 
 ### Fixed
 

--- a/GEOS_Util/post/remap_restart/remap_questions.py
+++ b/GEOS_Util/post/remap_restart/remap_questions.py
@@ -152,6 +152,7 @@ def ask_questions():
              2880X1440  (OSTIA) \n \
              CS = same as atmosphere grid (OSTIA cubed-sphere) \n",
             "choices": ['360X180','1440X720','2880X1440','CS'],
+            "default": lambda x: data_ocean_default(x.get('input:shared:agrid')),
             "when": lambda x: x.get('input:shared:model') == 'data' and not x['input:shared:MERRA-2'],
         },
 

--- a/GEOS_Util/post/remap_restart/remap_questions.py
+++ b/GEOS_Util/post/remap_restart/remap_questions.py
@@ -22,12 +22,12 @@ def fvcore_name(x):
   files = glob.glob(rst_dir+'/*fvcore_*'+time+'*')
   if len(files) ==1 :
     fname = files[0]
-    print('\nFound ' + fname) 
+    print('\nFound ' + fname)
     return fname
   else:
     fname = rst_dir+'/fvcore_internal_rst'
     if os.path.exists(fname):
-       print('\nFound ' + fname) 
+       print('\nFound ' + fname)
        return fname
     return False
 
@@ -35,13 +35,18 @@ def tmp_merra2_dir(x):
    tmp_merra2 = x['output:shared:out_dir']+ '/merra2_tmp_'+x['input:shared:yyyymmddhh']+'/'
    return tmp_merra2
 
+def data_ocean_default(resolution):
+   default_ = 'CS'
+   if resolution in ['C12','C24', 'C48'] : default_ = '360X180'
+   return default_
+
 def we_default(tag):
    default_ = '26'
    if tag in ['INL','GITNL', '525'] : default_ = '13'
    return default_
 
 def zoom_default(x):
-   zoom_ = '8'   
+   zoom_ = '8'
    fvcore = fvcore_name(x)
    if fvcore :
       fvrst = os.path.dirname(os.path.realpath(__file__)) + '/fvrst.x -h '
@@ -145,7 +150,7 @@ def ask_questions():
              360X180  (Reynolds) \n \
              1440X720 (MERRA-2) \n \
              2880X1440  (OSTIA) \n \
-             CS = same as atmospere grid (OSTIA cubed-sphere) \n",
+             CS = same as atmosphere grid (OSTIA cubed-sphere) \n",
             "choices": ['360X180','1440X720','2880X1440','CS'],
             "when": lambda x: x.get('input:shared:model') == 'data' and not x['input:shared:MERRA-2'],
         },
@@ -160,8 +165,9 @@ def ask_questions():
         {
             "type": "select",
             "name": "output:shared:ogrid",
-            "message": "Select new ocean grid:", 
+            "message": "Select new ocean grid:",
             "choices": ['360X180','1440X720','2880X1440','CS'],
+            "default": lambda x: data_ocean_default(x.get('output:shared:agrid')),
             "when": lambda x: x['output:shared:model'] == 'data',
         },
 
@@ -342,13 +348,13 @@ def get_config_from_questionary():
    config['output']['air'] = {}
    config['output']['surface'] = {}
    config['output']['analysis'] = {}
-   config['slurm'] = {} 
+   config['slurm'] = {}
    for key, value in answers.items():
      keys = key.split(":")
      if len(keys) == 2:
-       config[keys[0]][keys[1]] = value 
+       config[keys[0]][keys[1]] = value
      if len(keys) == 3:
-       config[keys[0]][keys[1]][keys[2]] = value 
+       config[keys[0]][keys[1]][keys[2]] = value
 
    return config
 

--- a/GEOS_Util/post/remap_restart/remap_utils.py
+++ b/GEOS_Util/post/remap_restart/remap_utils.py
@@ -104,8 +104,10 @@ def merra2_expid(config):
       expid = "d5124_m2_jan79"
    elif (yyyymm < 200106):
       expid = "d5124_m2_jan91"
-   elif (yyyymm < 202106):
+   elif (yyyymm < 201101):
       expid = "d5124_m2_jan00"
+   elif (yyyymm < 202106):
+      expid = "d5124_m2_jan10"
    # There was a rewind in MERRA2 from Jun 2021 to Sept 2021
    elif (yyyymm < 202110):
       expid = "d5124_m2_jun21"


### PR DESCRIPTION
In using `remap_restarts.py` I found a bug in the handling of MERRA2. This fixes it to be consistent with `regrid.pl`

Also, set the default data ocean for C90+ to be `CS` as that is usually what people use.