### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,27 +3,16 @@
 # Order is important; the last matching pattern takes the most
 # precedence.
 
-# Everything in GMAO_Shared should have an owner, default to cmake team
-# so that Tom or I (et al) are notified
-* @GEOS-ESM/gcm-gatekeepers
+# Both ADAS and GCM should be notified of changes in GMAO_Shared
+* @GEOS-ESM/adas-gatekeepers @GEOS-ESM/gcm-gatekeepers
 
 # Cmake team manages the circleci and github dirs
 /.circleci/ @GEOS-ESM/cmake-team
-/.github/ @GEOS-ESM/cmake-team
+/.github/   @GEOS-ESM/cmake-team
 
-# Postprocessing team is the CODEOWNER for plots and post
-/GEOS_Util/plots/ @GEOS-ESM/postprocessing-team
-/GEOS_Util/post/ @GEOS-ESM/postprocessing-team
+# GEOS_Shared has files that the Land Team also cares 
+# about (surfacelayer, etc.).
+/GEOS_Shared/ @GEOS-ESM/adas-gatekeepers @GEOS-ESM/gcm-gatekeepers @GEOS-ESM/land-team
 
-# Preprocessing team is the CODEOWNER for pre
-/GEOS_Util/pre/ @GEOS-ESM/preprocessing-team
-
-# Yuri owns the coupled plots
-/GEOS_Util/coupled_diagnostics/ @yvikhlya 
-
-# The Python Transition Team will own Python files
-# until the Python 3 transition is completed
-*.py @GEOS-ESM/python-transition-team
-
-# The GEOS CMake Team is the CODEOWNER for the CMakeLists.txt files in this repository
-CMakeLists.txt @GEOS-ESM/cmake-team
+# The GEOS CMake Team should also see CMakeLists.txt files in this repository
+CMakeLists.txt @GEOS-ESM/cmake-team @GEOS-ESM/adas-gatekeepers @GEOS-ESM/gcm-gatekeepers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,8 +3,9 @@
 # Order is important; the last matching pattern takes the most
 # precedence.
 
-# The ADAS is now the primary gatekeeper
-* @GEOS-ESM/adas-gatekeepers
+# Inform both ADAS and GCM Gatekeepers on changes
+# This could get more specific over time
+* @GEOS-ESM/adas-gatekeepers @GEOS-ESM/gcm-gatekeepers
 
 # Cmake team manages the circleci and github dirs
 /.circleci/ @GEOS-ESM/cmake-team
@@ -14,7 +15,7 @@
 /GEOS_Shared/ @GEOS-ESM/adas-gatekeepers @GEOS-ESM/gcm-gatekeepers @GEOS-ESM/land-team
 
 # LANL_Shared is seaice territory
-/LANL_Shared/ @GEOS-ESM/adas-gatekeepers @GEOS-ESM/seaice-team
+/LANL_Shared/ @GEOS-ESM/adas-gatekeepers @GEOS-ESM/gcm-gatekeepers @GEOS-ESM/seaice-team
 
 # The GEOS CMake Team should also see CMakeLists.txt files in this repository
-CMakeLists.txt @GEOS-ESM/cmake-team @GEOS-ESM/adas-gatekeepers
+CMakeLists.txt @GEOS-ESM/cmake-team @GEOS-ESM/adas-gatekeepers @GEOS-ESM/gcm-gatekeepers 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,16 +3,18 @@
 # Order is important; the last matching pattern takes the most
 # precedence.
 
-# Both ADAS and GCM should be notified of changes in GMAO_Shared
-* @GEOS-ESM/adas-gatekeepers @GEOS-ESM/gcm-gatekeepers
+# The ADAS is now the primary gatekeeper
+* @GEOS-ESM/adas-gatekeepers
 
 # Cmake team manages the circleci and github dirs
 /.circleci/ @GEOS-ESM/cmake-team
 /.github/   @GEOS-ESM/cmake-team
 
-# GEOS_Shared has files that the Land Team also cares 
-# about (surfacelayer, etc.).
+# GEOS_Shared has files that the GCM and Land Team care about
 /GEOS_Shared/ @GEOS-ESM/adas-gatekeepers @GEOS-ESM/gcm-gatekeepers @GEOS-ESM/land-team
 
+# LANL_Shared is seaice territory
+/LANL_Shared/ @GEOS-ESM/adas-gatekeepers @GEOS-ESM/seaice-team
+
 # The GEOS CMake Team should also see CMakeLists.txt files in this repository
-CMakeLists.txt @GEOS-ESM/cmake-team @GEOS-ESM/adas-gatekeepers @GEOS-ESM/gcm-gatekeepers
+CMakeLists.txt @GEOS-ESM/cmake-team @GEOS-ESM/adas-gatekeepers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated `CODEOWNERS` as GEOS_Util has been moved
+
 ### Fixed
 
 ### Removed


### PR DESCRIPTION
With the move of GEOS_Util to its own repo, it is time to update the `CODEOWNERS`.

The main changes are:

1. Make @GEOS-ESM/adas-gatekeepers the primary CODEOWNER of this repo.
2. GEOS_Shared has files that everyone cares about so add GCM and Land as CODEOWNER
3. LANL_Shared is @GEOS-ESM/seaice-team territory add them

Inspired by discussion at https://github.com/GEOS-ESM/GEOSldas/pull/623