### PR TITLE
Fixes for GEOS-IT CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ commands:
     steps:
       - run: |
           cd ${CIRCLE_WORKING_DIRECTORY}
-          git clone https://github.com/GEOS-ESM/<< parameters.repo >>.git
+          git clone -b v10.19.3 https://github.com/GEOS-ESM/<< parameters.repo >>.git
 
   mepoclone:
     description: "Mepo clone external repos"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ commands:
     steps:
       - run: |
           cd ${CIRCLE_WORKING_DIRECTORY}
-          git clone -b v10.19.3 https://github.com/GEOS-ESM/<< parameters.repo >>.git
+          git clone -b GEOS-IT-for-CI https://github.com/GEOS-ESM/<< parameters.repo >>.git
 
   mepoclone:
     description: "Mepo clone external repos"
@@ -134,8 +134,8 @@ jobs:
           compiler: << parameters.compiler >>
       - mepoclone:
           repo: GEOSgcm
-      - mepodevelop:
-          repo: GEOSgcm
+      #- mepodevelop:
+          #repo: GEOSgcm
       - checkout_feature_branch:
           repo: GEOSgcm
       - cmake:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-### Changed
-
-### Removed
-
-### Added
-
-### Fixed
+- Updated CI to work with GEOS-IT repos
 
 ### Changed
 


### PR DESCRIPTION
This is an attempt to fix up the CI for PRs to the GEOS-IT branch.

Fixing version of GEOSgcm to a branch `GEOS-IT-for-CI` which is based on the GEOSadas `GEOS-IT` branch.

Also, turning off the `mepodevelop` stage as that will cause issues.