### PR TITLE
Update CI to use Baselibs 7.13.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 # Anchors to prevent forgetting to update a version
-baselibs_version: &baselibs_version v7.7.0
-bcs_version: &bcs_version v10.22.3
+baselibs_version: &baselibs_version v7.13.0
+bcs_version: &bcs_version v11.00.0
 
 orbs:
   ci: geos-esm/circleci-tools@1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update CI to use Baselibs 7.13.0 like GEOSgcm v11.1.0
+
 ### Fixed
 
 ### Removed


### PR DESCRIPTION
This PR updates the CI to point to Baselibs 7.13.0 which is the version used by GEOSgcm on `main`