### PR TITLE
Fixes for perl 5.26 on SLES15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixes for Perl 5.26 on SLES15
+
 ### Removed
 
 ## [1.9.5] - 2023-10-18

--- a/GMAO_etc/WriteLog.pm
+++ b/GMAO_etc/WriteLog.pm
@@ -624,7 +624,7 @@ sub expand_EnvVars {
 
     # look for ${var} format
     #-----------------------
-    while ($string =~ m/(\${(\w+)})/)   {
+    while ($string =~ m/(\$\{(\w+)\})/)   {
         $var = $1; $name = $2;
         $var =~ s/\$/\\\$/;
         $string =~ s/$var/$ENV{$name}/;


### PR DESCRIPTION
Tests of `regrid.pl` on SLES15 by @sdrabenh found that Perl 5.26 acts differently. He got:
```
Unescaped left brace in regex is illegal here in regex; marked by <-- HERE in m/(\${ <-- HERE (\w+)})/ at /gpfsm/dnb78s1/projects/p18/sdrabenh/Models/KM_v11.3.2/install-SLES15/bin/WriteLog.pm line 627.
```

Searches online show that in Perl 5.26 [literal braces must be escaped](https://perldoc.perl.org/5.26.0/perldelta#Unescaped-literal-%22%7B%22-characters-in-regular-expression-patterns-are-no-longer-permissible)

Tests will be needed to make sure this doesn't break runs of `regrid.pl` on SLES12