### PR TITLE
Add pinning flags for Open MPI in esma_mpirun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Use '--bind-to core --map-by core' for Open MPI
+
 ### Fixed
 
 ### Removed

--- a/GMAO_etc/esma_mpirun
+++ b/GMAO_etc/esma_mpirun
@@ -331,9 +331,12 @@ sub get_xtraflags {
 
        if ($siteID eq "gmao") {
           $xtraflags .= " -oversubscribe";
-       } elsif ($perhost) {
-          $xtraflags .= " -map-by ppr:$perhost:node -bind-to core";
        }
+       if ($perhost) {
+          $xtraflags .= " -map-by ppr:$perhost:node";
+       }
+
+       $xtraflags .= " --bind-to core --map-by core";
 
     }
 


### PR DESCRIPTION
This PR updates GEOS to use `--bind-to core --map-by core` by default with Open MPI

ETA: In ongoing testing, `--bind-to core --map-by core` seems to be *slower* than the "no option" `mpirun`. 