### PR TITLE
Update R21C CI to work

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,5 +21,6 @@ workflows:
           baselibs_version: *baselibs_version
           repo: GEOSgcm
           checkout_fixture: true
+          fixture_branch: R21C
           mepodevelop: true
           persist_workspace: false # Needs to be true to run fv3/gcm experiment, costs extra


### PR DESCRIPTION
This PR updates the CI to use a tracking branch on GEOSgcm named `R21C` so that the CI will work.