### PR TITLE
Update CI to use Intel 2024.1 and Intel MPI 2021.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
 version: 2.1
 
 # Anchors in case we need to override the defaults from the orb
-#baselibs_version: &baselibs_version v7.17.0
-#bcs_version: &bcs_version v11.4.0
+#baselibs_version: &baselibs_version v8.0.2
+#bcs_version: &bcs_version v11.3.0
 
 orbs:
-  ci: geos-esm/circleci-tools@2
+  ci: geos-esm/circleci-tools@dev:da63575391a4842d05bd465fb006e17d24b3246e
 
 workflows:
   build-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2.1
 #bcs_version: &bcs_version v11.3.0
 
 orbs:
-  ci: geos-esm/circleci-tools@dev:da63575391a4842d05bd465fb006e17d24b3246e
+  ci: geos-esm/circleci-tools@dev:09326afe12cc1ef2d7a0fe5889a9bda19ddb3a92
 
 workflows:
   build-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ workflows:
             - docker-hub-creds
           matrix:
             parameters:
-              compiler: [gfortran, ifort]
+              compiler: [ifort]
           requires:
             - build-GEOSgcm-on-<< matrix.compiler >>
           repo: GEOSgcm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Refactored helfsurface subroutines to improve the performance
+- Update CI to use Intel 2024.1
 
 ### Fixed
 


### PR DESCRIPTION
@weiyuan-jiang Says that Intel 2021.6 has an issue with his updated code in #348 . So this is a test to update the CI to use a newer Intel.