### PR TITLE
Fixes for Intel 2024.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed invalid Fortran in `GMAO_ods/ods_diagnc4.f90`
+- Added `stdlib.h` in `GMAO_pyobs/VegType_io.c` to fix compilation error with `icx`
+
 ### Removed
 
 ## [1.9.7] - 2024-01-30

--- a/GMAO_ods/ods_diagnc4.f90
+++ b/GMAO_ods/ods_diagnc4.f90
@@ -674,7 +674,7 @@ subroutine ods_diagnc4(fname, nymd, nhms, ods, rc)
 
      call get_1d_var(input_id,'Time',rvals,rc)
      if (rc /= 0) return
-     ods%data%time(1:nobs) = int(rvals * 60,)
+     ods%data%time(1:nobs) = int(rvals * 60)
 
      call get_1d_var(input_id,'Observation_Type',ivals,rc)
      if (rc /= 0) return

--- a/GMAO_pyobs/VegType_io.c
+++ b/GMAO_pyobs/VegType_io.c
@@ -6,6 +6,7 @@ routines from RAMS.
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 
 static FILE *file;
 


### PR DESCRIPTION
GEOSgcm (and thus GEOSadas) will soon move to use Intel oneAPI 2024.2 which is Intel `ifort` 2021.13 and `icx` 2024.2.

Tests showed two issues. First there was a plain Fortran bug in `GMAO_ods/ods_diagnc4.F90`:

```fortran
     ods%data%time(1:nobs) = int(rvals * 60,)
```

That trailing comma is just wrong.

`icx` also threw an error with some C code:

```
/discover/swdev/mathomp4/Models/GEOSadas-MAPLdevelop-Baselibs-7.25.0/src/Shared/@GMAO_Shared/GMAO_pyobs/VegType_io.c:17:5: error: call to undeclared library function 'exit' with type 'void (int) __attribute__((noreturn))'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   17 |     exit(1);
      |     ^
/discover/swdev/mathomp4/Models/GEOSadas-MAPLdevelop-Baselibs-7.25.0/src/Shared/@GMAO_Shared/GMAO_pyobs/VegType_io.c:17:5: note: include the header <stdlib.h> or explicitly provide a declaration for 'exit'
```

As the error states, we add `#include <stdlib.h>`