### PR TITLE
Update n4zip to fix deprecated option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update `n4zip` with long option for non-alphabetical sorting
+
 ### Fixed
 
 ### Removed

--- a/GMAO_etc/n4zip
+++ b/GMAO_etc/n4zip
@@ -1,4 +1,4 @@
-#!/bin/csh 
+#!/bin/csh -f
 #
 # Packs NetCDF files with ncks with gzip level 4;
 # the file is made setgid to indicate that it is packed;
@@ -7,15 +7,11 @@
 #----------------------------------------------------------------
 
   set arch = `uname -s`
-  set ncks_opts = "--history --abc -4 -L 2 --cnk_dmn lev,1 "
+  set ncks_opts = "--history --no-alphabetize -4 -L 2 --cnk_dmn lev,1 "
   set ncks = "$BASEDIR/$arch/bin/ncks ${ncks_opts}"
-
-###  set ncks = "$SHARE/dasilva/bin/ncks ${ncks_opts}"
-####  set libs = "$SHARE/dasilva/opengrads/Contents/Linux/Versions/2.0.a5.oga.5/x86_64/gex"
 
   if ( $#argv < 1 ) then
         echo "n4zip - internal gzip packing of NetCDF-4 files"
-#	echo "usage:  n4zip [-n] [-nbits n] [-u undef] [-v]  nc4_filename(s)"
 	echo "usage:  n4zip [-n] [-v]  nc_filename(s)"
         echo "The option -n means dryrun"
 	exit 1
@@ -99,7 +95,7 @@
       if ( "$type" != "setgid" ) then
            echo -n $0": working on" `basename $file` " ..."
 #           $dryrun $ncks $verb $nbits $undef -i $file -o $file~ -t '*:GZIP 2'
-           $dryrun $ncks $file $file~ 
+           $dryrun $ncks $file $file~
            if ( $status ) then
                 set ok = 0
   	        echo " not ok"


### PR DESCRIPTION
As pointed out by @gmao-yzhu, when you run `n4zip` you get a big warning from NCO:

```
> /discover/nobackup/mathomp4/SystemTests/builds/AGCM/CURRENT/GEOSgcm/install-Release/bin/n4zip stock-2024Jul26-1day-c24-SLES15.geosgcm_prog.20000415_1800z.nc4
/discover/nobackup/mathomp4/SystemTests/builds/AGCM/CURRENT/GEOSgcm/install-Release/bin/n4zip: working on stock-2024Jul26-1day-c24-SLES15.geosgcm_prog.20000415_1800z.nc4  ...ncks: WARNING the ncks '-a', '--abc', and '--alphabetize' switches are misleadingly named because they turn-off the default alphabetization. These switches are deprecated as of NCO 4.7.1 and will soon be deleted. Instead, please use the new long options --no_abc, --no-abc, --no_alphabetize, or --no-alphabetize, all of which turn-off the default alphabetization.
 ok
```

So, to avoid this, we update the `--abc` to `--no-alphabetize`.

Also, add `-f` to the csh shebang. Always good practice.