### PR TITLE
Update ESMF CMake target to ESMF::ESMF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update ESMF CMake target to `ESMF::ESMF`
+
 ### Fixed
 
 ### Removed

--- a/GEOS_Shared/CMakeLists.txt
+++ b/GEOS_Shared/CMakeLists.txt
@@ -8,7 +8,7 @@ set (srcs
   getco2.F90 atmOceanIntLayer.F90
   )
 
-esma_add_library(${this} SRCS ${srcs} DEPENDENCIES MAPL esmf NetCDF::NetCDF_Fortran)
+esma_add_library(${this} SRCS ${srcs} DEPENDENCIES MAPL ESMF::ESMF NetCDF::NetCDF_Fortran)
 
 # special cases
 set_source_files_properties(sphere.F PROPERTIES COMPILE_FLAGS "${FREAL8}")

--- a/GMAO_stoch/CMakeLists.txt
+++ b/GMAO_stoch/CMakeLists.txt
@@ -45,7 +45,7 @@ set (srcs
 
  esma_add_library(${this}
    SRCS ${srcs}
-   DEPENDENCIES GMAO_mpeu GMAO_gfio_r8 GMAO_transf MAPL NCEP_sfcio NCEP_sp_r4i4 esmf NetCDF::NetCDF_Fortran
+   DEPENDENCIES GMAO_mpeu GMAO_gfio_r8 GMAO_transf MAPL NCEP_sfcio NCEP_sp_r4i4 ESMF::ESMF NetCDF::NetCDF_Fortran
    )
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
 


### PR DESCRIPTION
This PR updates the ESMF CMake target to `ESMF::ESMF` which is the correct canonical target name for ESMF. This is necessary for Spack compatibility. NOTE: This requires ESMF 8.6.1 or later.