### PR TITLE
General handling of GMAO-preqc files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated observation resource files for M21C
+- Generalize handling of obsys.rc for reanalysis when prebufr files are created
+  within the DAS by preQC
 
 ## [v1.7.2+R21C_v1.0.0] - 2024-03-01
 

--- a/GMAO_etc/obsys-nccs-r21c.rc
+++ b/GMAO_etc/obsys-nccs-r21c.rc
@@ -488,11 +488,11 @@ BEGIN r21c_gmi_bufr => gmi.%y4%m2%d2.t%h2z.bufr
 END
 
 #-------------------------
-BEGIN gmao_prep_bufr => EXPID.prepbufr.%y4%m2%d2.t%h2z.blk
- 19961231_00z-20211231_18z 060000 FVHOME/EXPID/atmens/central/EXPID.prepbufr.%y4%m2%d2.t%h2z.blk
+BEGIN gmao_prep_bufr => $EXPID.prepbufr.%y4%m2%d2.t%h2z.bfr
+ 19961231_00z-20211231_18z 060000 $FVHOME/atmens/central/$EXPID.prepbufr.%y4%m2%d2.t%h2z.blk
 END
 BEGIN gmao_acftpfl_bufr => EXPID.acft_profl.%y4%m2%d2.t%h2z.bfr
- 19961231_00z-20211231_18z 060000 FVHOME/EXPID/atmens/central/EXPID.acft_profl.%y4%m2%d2.t%h2z.bfr
+ 19961231_00z-20211231_18z 060000 $FVHOME/atmens/central/$EXPID.acft_profl.%y4%m2%d2.t%h2z.bfr
 END
 
 

--- a/GMAO_etc/obsys-nccs-r21c.rc
+++ b/GMAO_etc/obsys-nccs-r21c.rc
@@ -491,7 +491,7 @@ END
 BEGIN gmao_prep_bufr => $EXPID.prepbufr.%y4%m2%d2.t%h2z.bfr
  19961231_00z-20211231_18z 060000 $FVHOME/atmens/central/$EXPID.prepbufr.%y4%m2%d2.t%h2z.blk
 END
-BEGIN gmao_acftpfl_bufr => EXPID.acft_profl.%y4%m2%d2.t%h2z.bfr
+BEGIN gmao_acftpfl_bufr => $EXPID.acft_profl.%y4%m2%d2.t%h2z.bfr
  19961231_00z-20211231_18z 060000 $FVHOME/atmens/central/$EXPID.acft_profl.%y4%m2%d2.t%h2z.bfr
 END
 


### PR DESCRIPTION
Instead of expecting the user to have to know that something needs to be filled in in obsys.rc to handle the internally generated prepbufr (and corresponding aircraft file) this generalizes it so that the FVHOME and EXPID get filled in on the fly by the DAS scripts. 