### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/changelog-enforcer.yml
+++ b/.github/workflows/changelog-enforcer.yml
@@ -8,11 +8,10 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: dangoslen/changelog-enforcer@v2
+    - uses: dangoslen/changelog-enforcer@v3
       with:
         changeLogPath: 'CHANGELOG.md'
-        skipLabels: 'Skip Changelog'
+        skipLabels: 'Skip Changelog,0 diff trivial,automatic,dependencies,github_actions'
         missingUpdateErrorMessage: >
             No update to CHANGELOG.md found! Please add a changelog
             entry to it describing your change.  Please note that the

--- a/.github/workflows/validate_yaml_files.yml
+++ b/.github/workflows/validate_yaml_files.yml
@@ -15,7 +15,7 @@ jobs:
   validate-YAML:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - id: yaml-lint
         name: yaml-lint
         uses: ibiqlik/action-yamllint@v3
@@ -24,7 +24,7 @@ jobs:
           format: colored
           config_file: .yamllint.yml
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: yamllint-logfile


### PR DESCRIPTION
Soon, GitHub will deprecate the upload-artifacts v3 action. This PR updates the action to the latest version, v4.

It also updates the checkout action to the latest version, v4, as well.