### PR TITLE
Build GMAO_ncdiag in GMAO_Shared with gfortran-13 

### DIFF
--- a/GMAO_ncdiag/nc_diag_cat/nc_diag_cat.F90
+++ b/GMAO_ncdiag/nc_diag_cat/nc_diag_cat.F90
@@ -77,7 +77,7 @@ program nc_diag_cat
     call nc_diag_cat_metadata_pass
     call cpu_time(stop_time)
     
-    write (info_str, "(A, F, A)") "Metadata read took ", stop_time - start_time, " seconds!"
+    write (info_str, "(A, F15.1, A)") "Metadata read took ", stop_time - start_time, " seconds!"
     call ncdc_info(trim(info_str))
     
 #ifdef USE_MPI
@@ -93,7 +93,7 @@ program nc_diag_cat
         call nc_diag_cat_metadata_alloc
         call cpu_time(stop_time)
         
-        write (info_str, "(A, F, A)") "Data preallocation took ", stop_time - start_time, " seconds!"
+        write (info_str, "(A, F15.1, A)") "Data preallocation took ", stop_time - start_time, " seconds!"
         call ncdc_info(trim(info_str))
 #ifdef USE_MPI
     end if
@@ -103,7 +103,7 @@ program nc_diag_cat
     call nc_diag_cat_data_pass
     call cpu_time(stop_time)
     
-    write (info_str, "(A, F, A)") "Data read took ", stop_time - start_time, " seconds!"
+    write (info_str, "(A, F15.1, A)") "Data read took ", stop_time - start_time, " seconds!"
     call ncdc_info(trim(info_str))
     
 #ifdef USE_MPI
@@ -113,7 +113,7 @@ program nc_diag_cat
         call nc_diag_cat_data_commit
         call cpu_time(stop_time)
         
-        write (info_str, "(A, F, A)") "Data commit took ", stop_time - start_time, " seconds!"
+        write (info_str, "(A, F15.1, A)") "Data commit took ", stop_time - start_time, " seconds!"
         call ncdc_info(trim(info_str))
     
 #ifdef DEBUG
@@ -126,7 +126,7 @@ program nc_diag_cat
         call ncdc_check(nf90_close(ncid_output))
         call cpu_time(stop_time)
         
-        write (info_str, "(A, F, A)") "Final data write took ", stop_time - start_time, " seconds!"
+        write (info_str, "(A, F15.1, A)") "Final data write took ", stop_time - start_time, " seconds!"
         call ncdc_info(trim(info_str))
 #ifdef USE_MPI
     endif

--- a/GMAO_ncdiag/nc_diag_cat/ncdc_climsg.F90
+++ b/GMAO_ncdiag/nc_diag_cat/ncdc_climsg.F90
@@ -29,6 +29,7 @@ module ncdc_climsg
             character(len=*), intent(in) :: err
 #ifdef ERROR_TRACEBACK
             integer(i_long)              :: div0
+            integer(i_long)              :: zero=0
 #endif
 #ifdef USE_MPI
                 write(*, "(A, I0, A)") &
@@ -42,7 +43,8 @@ module ncdc_climsg
 #ifdef ERROR_TRACEBACK
             write(*, "(A)") " ** Failed to concatenate NetCDF4."
             write(*, "(A)") "    (Traceback requested, triggering div0 error...)"
-            div0 = 1 / 0
+            div0 = 1/zero        ! Division by zero occurs at runtime, not compile time
+            write(*, "(A)") "    Error: Division by zero"
             write(*, "(A)") "    Couldn't trigger traceback, ending gracefully."
             write(*, "(A)") "    (Ensure floating point exceptions are enabled,"
             write(*, "(A)") "    and that you have debugging (-g) and tracebacks"

--- a/GMAO_ncdiag/nc_diag_cat/ncdc_realloc.F90
+++ b/GMAO_ncdiag/nc_diag_cat/ncdc_realloc.F90
@@ -313,12 +313,13 @@ module ncdc_realloc
             character(len=*), intent(in) :: err
 #ifdef ERROR_TRACEBACK
             integer(i_long)              :: div0
+            integer                      :: zero
 #endif
             write(*, "(A)") " **   ERROR: " // err
 #ifdef ERROR_TRACEBACK
             write(*, "(A)") " ** Failed to concatenate NetCDF4."
             write(*, "(A)") "    (Traceback requested, triggering div0 error...)"
-            div0 = 1 / 0
+            div0 = 1 / zero
             write(*, "(A)") "    Couldn't trigger traceback, ending gracefully."
             write(*, "(A)") "    (Ensure floating point exceptions are enabled,"
             write(*, "(A)") "    and that you have debugging (-g) and tracebacks"

--- a/GMAO_ncdiag/nc_diag_write/nc_diag_write_mod.F90
+++ b/GMAO_ncdiag/nc_diag_write/nc_diag_write_mod.F90
@@ -320,7 +320,7 @@ module nc_diag_write_mod
             if (.NOT. init_done) then
                 ! Special append mode - that means that we need to
                 ! assume that all definitions are set and locked.
-                if (present(append) .AND. (append == .TRUE.)) then
+                if (present(append) .AND. (append .eqv. .TRUE.)) then
                     ! Open the file in append mode!
                     call nclayer_check( nf90_open(filename, NF90_WRITE, ncid, &
                         bsize, cache_nelems = 16777216) ) ! Optimization settings
@@ -379,7 +379,7 @@ module nc_diag_write_mod
                 ! chaninfo/metadata/data2d to read the NetCDF files,
                 ! build a cache, and set up anything necessary to be
                 ! able to resume writing from before.
-                if (present(append) .AND. (append == .TRUE.)) then
+                if (present(append) .AND. (append .eqv. .TRUE.)) then
                     call nclayer_info("Loading chaninfo variables/dimensions from file:")
                     call nc_diag_chaninfo_load_def
                     

--- a/GMAO_ncdiag/nc_diag_write/ncdw_chaninfo.F90
+++ b/GMAO_ncdiag/nc_diag_write/ncdw_chaninfo.F90
@@ -985,7 +985,7 @@ module ncdw_chaninfo
                                     
                                     ! Enable zlib (gzip-like) compression based on our level settings
                                     call nclayer_check(nf90_def_var_deflate(ncid, diag_chaninfo_store%var_ids(curdatindex), &
-                                        1, 1, NLAYER_COMPRESSION))
+                                        1, 1, int(NLAYER_COMPRESSION)))
                                 end if
                             end do
                             

--- a/GMAO_ncdiag/nc_diag_write/ncdw_data2d.F90
+++ b/GMAO_ncdiag/nc_diag_write/ncdw_data2d.F90
@@ -554,7 +554,7 @@ module ncdw_data2d
 #endif
                         if (.NOT. append_only) &
                             call nclayer_check(nf90_def_var_deflate(ncid, diag_data2d_store%var_ids(curdatindex), &
-                                1, 1, NLAYER_COMPRESSION))
+                                1, 1, int(NLAYER_COMPRESSION)))
                         
 #ifdef _DEBUG_MEM_
                         print *, "Done defining compression..."

--- a/GMAO_ncdiag/nc_diag_write/ncdw_metadata.F90
+++ b/GMAO_ncdiag/nc_diag_write/ncdw_metadata.F90
@@ -422,7 +422,7 @@ module ncdw_metadata
                             print *, "Defining compression 2 (gzip)..."
 #endif
                             call nclayer_check(nf90_def_var_deflate(ncid, diag_metadata_store%var_ids(curdatindex), &
-                                1, 1, NLAYER_COMPRESSION))
+                                1, 1, int(NLAYER_COMPRESSION)))
                             
 #ifdef _DEBUG_MEM_
                             print *, "Done defining compression..."

--- a/GMAO_ods/CMakeLists.txt
+++ b/GMAO_ods/CMakeLists.txt
@@ -116,7 +116,7 @@ separate_arguments(ODSMETA_ARGS NATIVE_COMMAND "sed -e 's/integer, parameter//g'
 add_custom_command (
    OUTPUT odsmeta.py
    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-   SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/odsmeta.h
+   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/odsmeta.h
    COMMAND grep 'integer, parameter' ${CMAKE_CURRENT_SOURCE_DIR}/odsmeta.h | ${ODSMETA_ARGS} | grep -v idsats > odsmeta.py
    )
 


### PR DESCRIPTION
This is a note to @mathomp4:
I am only building  src/GMAO_Shared/GMAO_ncdiag with gfortran-13,  excluding all other directories in GMAO_Shared.
I find GNU compiler complains many small Fortran errors and I find the logic to fix them.
I have  in src/CMakeLists.txt
```
if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
    set(BIG_ENDIAN "-fconvert=swap")
endif()

add_subdirectory (GMAO_Shared)
```
as I find a build error that `BIG_ENDIAN` was not defined, but this did not occur when building more directories in GMAO_Shared for GNU (hence it is just a stand alone test note).

 