### PR TITLE
Updates for GEOSadas 5.29.5 on SLES15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixes for Intel 2021.6
+
 ### Changed
 
 - update to remote_util.pl to serve OPS-spec needs

--- a/GMAO_ncdiag/nc_diag_cat/netcdf_unlimdims.F90
+++ b/GMAO_ncdiag/nc_diag_cat/netcdf_unlimdims.F90
@@ -21,8 +21,8 @@ module netcdf_unlimdims
         ! pf = polyfill
         integer(c_int) function pf_nf90_inq_unlimdims(ncid, num_unlim_dims, unlim_dims)
             integer(c_int), intent(in)            :: ncid
-            integer(c_int), intent(inout)         :: num_unlim_dims
-            integer(c_int), intent(out), optional :: unlim_dims(:)
+            integer(c_int), target, intent(inout)         :: num_unlim_dims
+            integer(c_int), target, intent(out), optional :: unlim_dims(:)
             
             integer :: i
             


### PR DESCRIPTION
This brings over changes to allow building on SLES15.