### PR TITLE
Updates for MVAPICH 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updates for `esma_mpirun` and MVAPICH 4
+  - Always bind to core
+
 ### Fixed
 
 - Corrected perl scripts for left/right brace error introduced with SLES-15:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updates for `esma_mpirun` and MVAPICH 4
-- Always bind to core
+  - Always bind to core
 - Refactored helfsurface subroutines to improve the performance
 
 ### Fixed

--- a/GMAO_etc/esma_mpirun
+++ b/GMAO_etc/esma_mpirun
@@ -338,6 +338,9 @@ sub get_xtraflags {
     }
 
     if ($mpi_type eq "mvapich") {
+       # Testing found that we need to run with -bind-to core
+       # if GEOS is to run well
+       $xtraflags .= " -bind-to core";
        if ($perhost) {
           $xtraflags .= " -ppn $perhost";
        }


### PR DESCRIPTION
Testing with MVAPICH 4 on discover found we need to always bind to cores with GEOS. This automates it.