### PR TITLE
Fix issue with unprotected f2py code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,46 @@
+# Global Editor Config for MAPL
+#
+# This is an ini style configuration. See http://editorconfig.org/ for more information on this file.
+#
+# Top level editor config.
+root = true
+
+# Always use Unix style new lines with new line ending on every file and trim whitespace
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Fortran: 3 spaces for indentation and max line length of 132 characters
+# Note: .pf files are Fortran
+[{*.f90,*.F90,*.pf}]
+indent_style = space
+indent_size = 3
+max_line_length = 132
+
+# Fortran Include files: 3 spaces for indentation and max line length of 132 characters
+# Note: In MAPL, .H and .h files are almost always Fortran and not C code
+[{*.inc,*.H,*.h}]
+indent_style = space
+indent_size = 3
+max_line_length = 132
+
+# Python: PEP8 defines 4 spaces for indentation
+[*.py]
+indent_style = space
+indent_size = 4
+
+# YAML format, 2 spaces
+[{*.yaml,*.yml}]
+indent_style = space
+indent_size = 2
+
+# CMake (from KitWare: https://github.com/Kitware/CMake/blob/master/.editorconfig)
+[{CMakeLists.txt,*.cmake,*.rst}]
+indent_style = space
+indent_size = 2
+
+# Markdown
+[*.md]
+trim_trailing_whitespace = true
+indent_style = space

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [2.1.1] - 2025-05-13
+
+### Fixed
+
+- Fixed issue with unprotected f2py call in `GMAO_gfio`. Caused failures if build system did not have f2py available.
+
+### Added
+
+- Added `.editorconfig`
+
 ## [2.1.0] - 2025-04-23
 
 ### Added

--- a/GMAO_gfio/CMakeLists.txt
+++ b/GMAO_gfio/CMakeLists.txt
@@ -26,7 +26,7 @@ if (EXTENDED_SOURCE)
   set_target_properties (${this} PROPERTIES COMPILE_FLAGS ${EXTENDED_SOURCE})
 endif()
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
-  
+
 # Specs for r8 version
 if (precision STREQUAL "r8")
   string(REPLACE " " ";" tmp ${FREAL8})
@@ -45,19 +45,21 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories (${include_${this}})
 
 if (precision STREQUAL "r4")
-  find_package(F2PY3)
-  if (F2PY3_FOUND)
-    # Using add_ here as the import test threw an SSL error on GMAO desktop
-    esma_add_f2py3_module(GFIO_ SOURCES GFIO_py.F90
-      DESTINATION lib/Python
-      ONLY gfioopen gfiocreate gfiodiminquire gfioinquire
-      gfiogetvar gfiogetvart gfioputvar gfiogetbegdatetime
-      gfiointerpxy gfiointerpnn gfiocoordnn gfioclose
-      LIBRARIES GMAO_gfio_r4
-      INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${include_${this}}
-      USE_MPI USE_NETCDF
-      )
-    add_dependencies(GFIO_ ${this})
+  if (USE_F2PY)
+    find_package(F2PY3)
+    if (F2PY3_FOUND)
+      # Using add_ here as the import test threw an SSL error on GMAO desktop
+      esma_add_f2py3_module(GFIO_ SOURCES GFIO_py.F90
+        DESTINATION lib/Python
+        ONLY gfioopen gfiocreate gfiodiminquire gfioinquire
+        gfiogetvar gfiogetvart gfioputvar gfiogetbegdatetime
+        gfiointerpxy gfiointerpnn gfiocoordnn gfioclose
+        LIBRARIES GMAO_gfio_r4
+        INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${include_${this}}
+        USE_MPI USE_NETCDF
+        )
+      add_dependencies(GFIO_ ${this})
+    endif ()
   endif ()
 endif ()
 


### PR DESCRIPTION
Testing with GEOSfvdycore on Spack revealed an issue with f2py. Namely, the GFIO f2py code in CMake did not respect `-DUSE_F2PY:BOOL=OFF`. This PR fixes that.

I also add an `.editorconfig` file because I saw this didn't have it.