### PR TITLE
Fixes #386. Only install gmao2ioda if it exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [2.1.3] - 2025-07-07
+
+### Fixed
+
+- Fix issue with installing `gmao2ioda` scripts as the `gmao2ioda/` directory might not exist in all fixtures
+
 ## [2.1.2] - 2025-06-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed `cmpdir.pl` script and add extra functionality
-
 ### Removed
 
 ## [2.1.3] - 2025-07-07
@@ -22,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix issue with installing `gmao2ioda` scripts as the `gmao2ioda/` directory might not exist in all fixtures
+- Fixed `cmpdir.pl` script and add extra functionality
 
 ## [2.1.2] - 2025-06-30
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,9 +40,13 @@ if ( NOT HERMES_LIGHT )
    endif ()
 
    # the gmao2ioda directory just has scripts we want to install
-   install (
-     DIRECTORY gmao2ioda
-     DESTINATION bin
-     USE_SOURCE_PERMISSIONS
-   )
+   # but we only want to install it if it actually exists (i.e.,
+   # it might be sparsed out in some fixtures
+   if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/gmao2ioda)
+     install(
+       DIRECTORY gmao2ioda
+       DESTINATION bin
+       USE_SOURCE_PERMISSIONS
+     )
+   endif()
 endif()


### PR DESCRIPTION
Closes #386 

If the `gmao2ioda` directory doesn't exist, we can't `INSTALL` it. So, we check if it exists.