### PR TITLE
Update openmpi in esma_mpirun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated `esma_mpirun` for `openmpi` to run with `-map-by node -bind-to core` which is a good default.
+
 ### Fixed
 
 ### Removed

--- a/GMAO_etc/esma_mpirun
+++ b/GMAO_etc/esma_mpirun
@@ -331,8 +331,11 @@ sub get_xtraflags {
 
        if ($siteID eq "gmao") {
           $xtraflags .= " -oversubscribe";
-       } elsif ($perhost) {
+       }
+       if ($perhost) {
           $xtraflags .= " -map-by ppr:$perhost:node -bind-to core";
+       } else {
+          $xtraflags .= " -map-by node -bind-to core";
        }
 
     }


### PR DESCRIPTION
This PR updates how `esma_mpirun` is run with openmpi. It will run with `-map-by node -bind-to core`

Keeping draft until I fully test.