### PR TITLE
Fixes #394. Update gpy module in idcheck.pl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed gpy module in `idcheck.pl`
+
 ### Removed
 
 ### Deprecated

--- a/GMAO_etc/idcheck.pl
+++ b/GMAO_etc/idcheck.pl
@@ -87,7 +87,7 @@ sub check_semperpy_dbs {
     }
     $ENV{"MODULEPATH"} .= ":${modsDIR}";
     do "/usr/share/modules/init/perl";
-    module ("load gpy/sles12-v1.1.0");
+    module ("load gpy/sles15-py3.11.0");
     $ENV{"SEMPERPY_CONFIG"} = "/home/dao_ops/gmao_packages/o2h/o2h/config";
 
     # write .pgpass, if it does not already  exist


### PR DESCRIPTION
Closes #394 

As found by @metdyn, the `idcheck.pl` script points to a sles12 gpy module. That doesn't quite do in modern SLES15 NCCS.

So we move to use the SLES15 module in the same directory