### PR TITLE
Fix for Open MPI 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix for Open MPI calls in `esma_mpirun` from Open MPI 5 testing
+
 ### Removed
 
 ### Deprecated

--- a/GMAO_etc/esma_mpirun
+++ b/GMAO_etc/esma_mpirun
@@ -335,8 +335,6 @@ sub get_xtraflags {
        }
        if ($perhost) {
           $xtraflags .= " --map-by ppr:$perhost:node --bind-to core";
-       } else {
-          $xtraflags .= " --bind-to core";
        }
 
     }

--- a/GMAO_etc/esma_mpirun
+++ b/GMAO_etc/esma_mpirun
@@ -331,12 +331,12 @@ sub get_xtraflags {
     if ($mpi_type eq "openmpi") {
 
        if ($siteID eq "gmao") {
-          $xtraflags .= " -oversubscribe";
+          $xtraflags .= " --oversubscribe";
        }
        if ($perhost) {
-          $xtraflags .= " -map-by ppr:$perhost:node -bind-to core";
+          $xtraflags .= " --map-by ppr:$perhost:node --bind-to core";
        } else {
-          $xtraflags .= " -map-by node -bind-to core";
+          $xtraflags .= " --bind-to core";
        }
 
     }


### PR DESCRIPTION
Testing with Open MPI 5 on discover found that:

1. Open MPI 5 does not like `-flag` only `--flag`
2. That `--map-by node --bind-to core` was doing round robin distribution of tasks

So, we just remove it