### PR TITLE
Use LongName for FP collection descriptions in pyrob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated `pyrob` script for Forward Processing (`-F`) collection descriptions
+  - By default, the collection description is now taken from the `LongName` global
+    attribute of the netCDF file, with any leading `"GEOS FP "` prefix stripped
+  - Added `--no-longname` flag to revert to the legacy `Title`-based description
+    for older FP files that do not carry a useful `LongName` attribute
+  - The same `--no-longname` escape hatch applies to `--geosit` / `--m21c` runs
+
 ### Fixed
 
 - Fix for Open MPI calls in `esma_mpirun` from Open MPI 5 testing

--- a/GMAO_etc/pyrob
+++ b/GMAO_etc/pyrob
@@ -249,13 +249,24 @@ class Writer(object):
                 else:
                     descr = "fix me, please"
 
-        if options.geosit:
+        if options.geosit and not options.no_longname:
             if Coll.LongName is not None:
                 Descr = Coll.LongName.split()[4:]
                 descr = " ".join(Descr)
                 if "edge" in descr:
                     level = "Model-Level Edge"
                 descr = descr.title()
+
+        if options.fp and not options.no_longname:
+            if Coll.LongName is not None:
+                # Strip a leading "GEOS FP " prefix (case-insensitive) if present,
+                # then title-case the remainder for consistent formatting.
+                ln = Coll.LongName.strip()
+                for prefix in ("GEOS FP ", "GEOS-FP "):
+                    if ln.lower().startswith(prefix.lower()):
+                        ln = ln[len(prefix):]
+                        break
+                descr = ln.title()
 
         descr = (
             descr.replace("Forecast,", "")
@@ -1233,6 +1244,14 @@ if __name__ == "__main__":
         action="store_true",
         dest="fp",
         help="Assume Forward Processing file name conventions",
+    )
+
+    parser.add_option(
+        "--no-longname",
+        action="store_true",
+        dest="no_longname",
+        default=False,
+        help="Use legacy Title-based collection description instead of LongName global attribute (for older FP/GEOS-IT files)",
     )
 
     parser.add_option(


### PR DESCRIPTION
Per a request of @rlucches, for Forward Processing (`-F`) runs, `pyrob` now derives the collection description from the LongName global attribute of the netCDF file, stripping any leading 'GEOS FP ' prefix and title-casing the result.

A new `--no-longname` flag restores the legacy Title-based behavior for older FP (and GEOS-IT) files that predate the LongName attribute.

I tested this on a couple files:

Old behavior (`--no-longname`):
```
pyrob -F -v -H HISTORY.rc -f stdout --no-longname GEOS.fp.*.nc4
1) Collection inst1_2d_lfo_Nx (DFPI1NXLFO): Land Surface Forcings
2) Collection inst3_2d_asm_Nx (DFPI3NXASM): Single-Level Diagnostics
```

New default behavior (from LongName global attribute):
```
pyrob -F -v -H HISTORY.rc -f stdout GEOS.fp.*.nc4
1) Collection inst1_2d_lfo_Nx (DFPI1NXLFO): 2D Time-Averaged Land Surface Forcing
2) Collection inst3_2d_asm_Nx (DFPI3NXASM): 2D Assimilated State
```
