### PR TITLE
Add ABI kx info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add kx''s for ABI g16,g18 516,518)
+
 - Minor changes for VIIRS additions
 
 ### Changed

--- a/GMAO_ods/kx_register.tbl
+++ b/GMAO_ods/kx_register.tbl
@@ -490,6 +490,11 @@
 
 # see gsi.rc: OBS_INPUT::
 #  kx   source      dplat       dtype                   isat
+   516  gsi_diag    g16         abi                       16    # abi g16
+   518  gsi_diag    g18         abi                       18    # abi g18
+
+# see gsi.rc: OBS_INPUT::
+#  kx   source      dplat       dtype                   isat
    546  gsi_diag    aqua        amsre                      0    # amsre_aqua
    547  gsi_diag    aqua        amsre_low                  0    # amsre_aqua(low)
    548  gsi_diag    aqua        amsre_mid                  0    # amsre_aqua(mid)

--- a/GMAO_ods/odsmeta.h
+++ b/GMAO_ods/odsmeta.h
@@ -320,7 +320,7 @@
      7                 'ODSmatch could not find match   ',
      8                 'no impact due to advected local '/)
 
-      integer, parameter :: nsats = 58
+      integer, parameter :: nsats = 59
       character(len=*), parameter :: sats(nsats)=(/
      .                 'hirs2           ', 'hirs3           ', 'hirs4           ',
      .                 'msu             ', 'ssu             ', 'sndr            ',
@@ -341,7 +341,7 @@
      .                 'amsr2           ', 'ompsnmeff       ', 'ompsnpnc        ',
      .                 'amsre           ', 'ompslpnc        ', 'tgez            ',
      .                 'tgev            ', 'tgav            ', 'tgaz            ',
-     .                 'tgop            '  /)
+     .                 'tgop            ', 'abi'  /)
 
 ! note: numbers below were made up for MHS, and SSU
 ! note: CRIS and ATMS numbers assigned at will
@@ -367,7 +367,7 @@
      .                 550               , 428               , 438               ,
      .                 546               , 337               , 999               ,
      .                 999               , 999               , 999               ,
-     .                 999                 /)
+     .                 999               , 500  /)
 
       integer, parameter :: npcp = 4
       character(len=*), parameter :: pcpt(npcp)=(/

--- a/GMAO_ods/odsstats.rc
+++ b/GMAO_ods/odsstats.rc
@@ -52,6 +52,7 @@ OBS*Class*Kts::
    SEVIRI     40
    SSMI       40
 #  OMI        21
+   ABI        40
 ::
 
 OBS*Class*Kxs::
@@ -89,4 +90,5 @@ OBS*Class*Kxs::
    SEVIRI     989 990
    SSMI       708 710 711 713:715
 #  OMI        449
+   ABI        516 518
 ::

--- a/GMAO_ods/odsstats4jedi.rc
+++ b/GMAO_ods/odsstats4jedi.rc
@@ -18,6 +18,7 @@ OBS*Class*Kts::
    Radiosonde 4 5 11 33 44 
    ASCAT      4 5
    SATWIND    4 5
+   ABI        40
 #  AMSUA-AQA  40
    AMSUA-N15  40
    AMSUA-N18  40
@@ -59,6 +60,7 @@ OBS*Class*Kxs::
    ASCAT      290
 #  SATWIND    226:240
    SATWIND    242:259
+   ABI        516 518
 #  AMSUA-AQA  300
    AMSUA-N15  315
    AMSUA-N18  318

--- a/GMAO_ods/radiance-kx.readme
+++ b/GMAO_ods/radiance-kx.readme
@@ -26,6 +26,8 @@
  hirs4       n19         hirs4_n19                     19          19
  hirs4       metop-a     hirs4_metop-a                 25          25
  hirs4       metop-b     hirs4_metop-b                 26          26
+ abi         g16         abi_g16                       16         516
+ abi         g18         abi_g18                       18         518
  airs        aqua        airs_aqua                      0          49
  sndr        g08_prep    sndr_g08                       8          53
  sndr        g10_prep    sndr_g10                      10          55


### PR DESCRIPTION
516 and 518 are being assigned to ABI g16 and g18 respectively. Are these acceptable numbers? 

see issue #409 

@mhan-mars and @gmao-yzhu  notice this is not to go on main - that's why there are so many files changed in this PR - I will redirect this to another branch. I just need for you to coordinate with @AustinConaty  and confirm that KXs 516 and 518 are acceptable for ABI.