### PR TITLE
Restrict GMAO_Shared to HERMES_LIGHT on release/MAPL-v3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,55 @@
 esma_check_if_debug()
 
-# HERMES_LIGHT builds only m_set_eta.F90 from GMAO_hermes, which is
-# required by FVdycoreCubed_GridComp on release/MAPL-v3.
-option(HERMES_LIGHT "Build light-weighted GMAO_shared library" ON)
+option(HERMES_LIGHT "Build light-weighted GMAO_shared library" OFF)
 
-# Only GEOS_Shared and GMAO_hermes (light) are needed on release/MAPL-v3.
-# Restore remaining subdirs as components are ported to MAPL3.
 esma_add_subdirectories(GEOS_Shared)
 esma_add_subdirectories(GMAO_hermes)
+
+if ( NOT HERMES_LIGHT )
+
+   esma_add_subdirectories(
+     GMAO_mpeu
+     GMAO_pilgrim
+     GMAO_etc
+     GEOS_Util
+     LANL_Shared
+     GMAO_perllib
+     GMAO_transf
+     GMAO_stoch
+
+     GEOS_Pert
+     GMAO_mfhdf3
+     GMAO_gfioeos
+     GMAO_ods
+     GMAO_psas
+     GMAO_gems
+     GMAO_iret
+     GMAO_pyobs
+     GMAO_radmon
+
+     GMAO_ncdiag
+     arpack
+     pnagpack
+     )
+
+   # Special case - GMAO_gfio is built twice with two different precisions.
+   if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GMAO_gfio)
+     add_subdirectory (GMAO_gfio GMAO_gfio_r4)
+     add_subdirectory (GMAO_gfio GMAO_gfio_r8)
+     add_dependencies (GMAO_gfio_r4 GMAO_gfio_r8)
+   endif ()
+
+   # the gmao2ioda directory just has scripts we want to install
+   # but we only want to install it if it actually exists (i.e.,
+   # it might be sparsed out in some fixtures
+   if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/gmao2ioda)
+     install(
+       DIRECTORY gmao2ioda
+       DESTINATION bin
+       USE_SOURCE_PERMISSIONS
+     )
+   endif()
+endif()
 
 # if ( NOT HERMES_LIGHT )
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,54 +2,13 @@ esma_check_if_debug()
 
 option(HERMES_LIGHT "Build light-weighted GMAO_shared library" OFF)
 
-esma_add_subdirectories(GEOS_Shared)
+# not yet ported to MAPL3 - only build GMAO_mpeu, GMAO_hermes (light), and GEOS_Shared
+# for FVdycoreCubed_GridComp (needs m_set_eta, m_topo_remap, tropovars)
+# restore full build (and set HERMES_LIGHT OFF) when all components are ported
+set (HERMES_LIGHT ON)
+esma_add_subdirectories(GMAO_mpeu)
 esma_add_subdirectories(GMAO_hermes)
-
-if ( NOT HERMES_LIGHT )
-
-   esma_add_subdirectories(
-     GMAO_mpeu
-     GMAO_pilgrim
-     GMAO_etc
-     GEOS_Util
-     LANL_Shared
-     GMAO_perllib
-     GMAO_transf
-     GMAO_stoch
-
-     GEOS_Pert
-     GMAO_mfhdf3
-     GMAO_gfioeos
-     GMAO_ods
-     GMAO_psas
-     GMAO_gems
-     GMAO_iret
-     GMAO_pyobs
-     GMAO_radmon
-
-     GMAO_ncdiag
-     arpack
-     pnagpack
-     )
-
-   # Special case - GMAO_gfio is built twice with two different precisions.
-   if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GMAO_gfio)
-     add_subdirectory (GMAO_gfio GMAO_gfio_r4)
-     add_subdirectory (GMAO_gfio GMAO_gfio_r8)
-     add_dependencies (GMAO_gfio_r4 GMAO_gfio_r8)
-   endif ()
-
-   # the gmao2ioda directory just has scripts we want to install
-   # but we only want to install it if it actually exists (i.e.,
-   # it might be sparsed out in some fixtures
-   if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/gmao2ioda)
-     install(
-       DIRECTORY gmao2ioda
-       DESTINATION bin
-       USE_SOURCE_PERMISSIONS
-     )
-   endif()
-endif()
+esma_add_subdirectories(GEOS_Shared)
 
 # if ( NOT HERMES_LIGHT )
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,51 +2,53 @@ esma_check_if_debug()
 
 option(HERMES_LIGHT "Build light-weighted GMAO_shared library" OFF)
 
+# Only GEOS_Shared is needed on release/MAPL-v3 (required by GEOSgwd_GridComp).
+# Restore remaining subdirs as components are ported to MAPL3.
 esma_add_subdirectories(GEOS_Shared)
-esma_add_subdirectories(GMAO_hermes)
+# esma_add_subdirectories(GMAO_hermes)
 
-if ( NOT HERMES_LIGHT )
-
-   esma_add_subdirectories(
-     GMAO_mpeu
-     GMAO_pilgrim
-     GMAO_etc
-     GEOS_Util
-     LANL_Shared
-     GMAO_perllib
-     GMAO_transf
-     GMAO_stoch
-
-     GEOS_Pert
-     GMAO_mfhdf3
-     GMAO_gfioeos
-     GMAO_ods
-     GMAO_psas
-     GMAO_gems
-     GMAO_iret
-     GMAO_pyobs
-     GMAO_radmon
-
-     GMAO_ncdiag
-     arpack
-     pnagpack
-     )
-
-   # Special case - GMAO_gfio is built twice with two different precisions.
-   if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GMAO_gfio)
-     add_subdirectory (GMAO_gfio GMAO_gfio_r4)
-     add_subdirectory (GMAO_gfio GMAO_gfio_r8)
-     add_dependencies (GMAO_gfio_r4 GMAO_gfio_r8)
-   endif ()
-
-   # the gmao2ioda directory just has scripts we want to install
-   # but we only want to install it if it actually exists (i.e.,
-   # it might be sparsed out in some fixtures
-   if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/gmao2ioda)
-     install(
-       DIRECTORY gmao2ioda
-       DESTINATION bin
-       USE_SOURCE_PERMISSIONS
-     )
-   endif()
-endif()
+# if ( NOT HERMES_LIGHT )
+#
+#    esma_add_subdirectories(
+#      GMAO_mpeu
+#      GMAO_pilgrim
+#      GMAO_etc
+#      GEOS_Util
+#      LANL_Shared
+#      GMAO_perllib
+#      GMAO_transf
+#      GMAO_stoch
+#
+#      GEOS_Pert
+#      GMAO_mfhdf3
+#      GMAO_gfioeos
+#      GMAO_ods
+#      GMAO_psas
+#      GMAO_gems
+#      GMAO_iret
+#      GMAO_pyobs
+#      GMAO_radmon
+#
+#      GMAO_ncdiag
+#      arpack
+#      pnagpack
+#      )
+#
+#    # Special case - GMAO_gfio is built twice with two different precisions.
+#    if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/GMAO_gfio)
+#      add_subdirectory (GMAO_gfio GMAO_gfio_r4)
+#      add_subdirectory (GMAO_gfio GMAO_gfio_r8)
+#      add_dependencies (GMAO_gfio_r4 GMAO_gfio_r8)
+#    endif ()
+#
+#    # the gmao2ioda directory just has scripts we want to install
+#    # but we only want to install it if it actually exists (i.e.,
+#    # it might be sparsed out in some fixtures
+#    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/gmao2ioda)
+#      install(
+#        DIRECTORY gmao2ioda
+#        DESTINATION bin
+#        USE_SOURCE_PERMISSIONS
+#      )
+#    endif()
+# endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,13 @@
 esma_check_if_debug()
 
-option(HERMES_LIGHT "Build light-weighted GMAO_shared library" OFF)
+# HERMES_LIGHT builds only m_set_eta.F90 from GMAO_hermes, which is
+# required by FVdycoreCubed_GridComp on release/MAPL-v3.
+option(HERMES_LIGHT "Build light-weighted GMAO_shared library" ON)
 
-# Only GEOS_Shared is needed on release/MAPL-v3 (required by GEOSgwd_GridComp).
+# Only GEOS_Shared and GMAO_hermes (light) are needed on release/MAPL-v3.
 # Restore remaining subdirs as components are ported to MAPL3.
 esma_add_subdirectories(GEOS_Shared)
-# esma_add_subdirectories(GMAO_hermes)
+esma_add_subdirectories(GMAO_hermes)
 
 # if ( NOT HERMES_LIGHT )
 #

--- a/GMAO_hermes/CMakeLists.txt
+++ b/GMAO_hermes/CMakeLists.txt
@@ -81,9 +81,11 @@ else ()
 
    set (srcs
      m_set_eta.F90 shared_topo_remap.F90
+     # not yet ported to MAPL3 - added for FVdycoreCubed_GridComp (m_topo_remap dependency chain)
+     m_topo_remap.F90 m_dyn.f90 m_const.f90
      )
 
-   esma_add_library(${this} SRCS ${srcs} )
+   esma_add_library(${this} SRCS ${srcs} DEPENDENCIES GMAO_mpeu)
    target_compile_options(${this} PRIVATE ${flags})
 
 endif ()

--- a/GMAO_hermes/m_set_eta.F90
+++ b/GMAO_hermes/m_set_eta.F90
@@ -45,7 +45,8 @@
 CONTAINS
 
       subroutine set_eta_r8_ (km, ks, ptop, pint, ak, bk)
-      use, intrinsic :: iso_fortran_env, only : r8 => REAL64, r4 => REAL32
+      use m_realkinds, only : r8 => kind_r8  ! from mpeu
+      use m_realkinds, only : r4 => kind_r4  ! from mpeu
 
 #else
 
@@ -56,6 +57,51 @@ CONTAINS
 #endif
 
       implicit none
+
+! Choices for vertical resolutions are as follows:
+! NCAR: 18, 26, and 30
+! NASA DAO: smoothed version of CCM4's 30-level, 32, 48, 55
+! Revised 32-layer setup with top at 0.4 mb for high horizontal
+! resolution runs. (sjl: 04/01/2002)
+! Revised 55-level eta with pint at 176.93 mb  SJL: 2000-03-20
+!
+! NCEP 64-level sigma and hybrid eta
+
+! NCAR specific
+      real(r8) a18(19),b18(19)              ! CCM3
+      real(r8) a26(27),b26(27)              ! CCM4
+      real(r8) a30(31),b30(31)              ! CCM4
+
+! NASA only
+      real(r8) a01(2),b01(2)                ! to allow single-level utils to rely on sim code
+      real(r8) a30m(31),b30m(31)            ! smoothed CCM4 30-L
+      real(r8) a32(33),b32(33)
+      real(r8) a44(45),b44(45)
+      real(r8) a48(49),b48(49)
+      real(r8) a55(56),b55(56)
+      real(r8) a72(73),b72(73)   ! geos-5
+      real(r8) a91_EC(92),b91_EC(92)   ! Nature EC
+      real(r8) a96(97),b96(97)   ! not sure
+      real(r8) a72_ncep(73),b72_ncep(73)  ! mainly NCEP's 64 with the GMAO-72 top levels
+      real(r8) a144(145), b144(145)
+      real(r8) a132(133), b132(133)
+
+! ECMWF 137L Based levels
+      real(r8) a71(72), b71(72)
+      real(r8) a91(92), b91(92)
+      real(r8) a137(138), b137(138)
+      real(r8) a181(182), b181(182)
+
+! ML Increment Levels
+      integer l181tol41(42)
+
+! Extended model top
+      real(r8) a186(187), b186(187)
+
+! NCEP
+      real(r8) a64(65),b64(65), a64_sig(65),b64_sig(65)
+      real(r8) a127(128),b127(128)
+
       integer ks, k, km
       real(r8) ak(km+1),bk(km+1)
       real(r8) ptop                      ! model top (Pa)
@@ -1247,14 +1293,12 @@ CONTAINS
     subroutine set_eta_r4_ (km, ks, ptop, pint, ak, bk)
 
 #ifdef HERMES
-      use, intrinsic :: iso_fortran_env, only : r8 => REAL64, r4 => REAL32
-
+      use m_realkinds, only : r8 => kind_r8  ! from mpeu
+      use m_realkinds, only : r4 => kind_r4  ! from mpeu
 #else
-
       subroutine set_eta_r8_(km, ks, ptop, pint, ak, bk)
       use shr_kind_mod, only : r8 => shr_kind_r8 ! from gvgcm
       use shr_kind_mod, only : r4 => shr_kind_r4 ! from gvgcm
-
 #endif
       implicit none
       integer ks, k, km

--- a/GMAO_hermes/m_set_eta.F90
+++ b/GMAO_hermes/m_set_eta.F90
@@ -45,8 +45,7 @@
 CONTAINS
 
       subroutine set_eta_r8_ (km, ks, ptop, pint, ak, bk)
-      use m_realkinds, only : r8 => kind_r8  ! from mpeu
-      use m_realkinds, only : r4 => kind_r4  ! from mpeu
+      use, intrinsic :: iso_fortran_env, only : r8 => REAL64, r4 => REAL32
 
 #else
 
@@ -57,51 +56,6 @@ CONTAINS
 #endif
 
       implicit none
-
-! Choices for vertical resolutions are as follows:
-! NCAR: 18, 26, and 30
-! NASA DAO: smoothed version of CCM4's 30-level, 32, 48, 55
-! Revised 32-layer setup with top at 0.4 mb for high horizontal
-! resolution runs. (sjl: 04/01/2002)
-! Revised 55-level eta with pint at 176.93 mb  SJL: 2000-03-20
-!
-! NCEP 64-level sigma and hybrid eta
-
-! NCAR specific
-      real(r8) a18(19),b18(19)              ! CCM3
-      real(r8) a26(27),b26(27)              ! CCM4
-      real(r8) a30(31),b30(31)              ! CCM4
-
-! NASA only
-      real(r8) a01(2),b01(2)                ! to allow single-level utils to rely on sim code
-      real(r8) a30m(31),b30m(31)            ! smoothed CCM4 30-L
-      real(r8) a32(33),b32(33)
-      real(r8) a44(45),b44(45)
-      real(r8) a48(49),b48(49)
-      real(r8) a55(56),b55(56)
-      real(r8) a72(73),b72(73)   ! geos-5
-      real(r8) a91_EC(92),b91_EC(92)   ! Nature EC
-      real(r8) a96(97),b96(97)   ! not sure
-      real(r8) a72_ncep(73),b72_ncep(73)  ! mainly NCEP's 64 with the GMAO-72 top levels
-      real(r8) a144(145), b144(145)
-      real(r8) a132(133), b132(133)
-
-! ECMWF 137L Based levels
-      real(r8) a71(72), b71(72)
-      real(r8) a91(92), b91(92)
-      real(r8) a137(138), b137(138)
-      real(r8) a181(182), b181(182)
-
-! ML Increment Levels
-      integer l181tol41(42)
-
-! Extended model top
-      real(r8) a186(187), b186(187)
-
-! NCEP
-      real(r8) a64(65),b64(65), a64_sig(65),b64_sig(65)
-      real(r8) a127(128),b127(128)
-
       integer ks, k, km
       real(r8) ak(km+1),bk(km+1)
       real(r8) ptop                      ! model top (Pa)
@@ -1293,12 +1247,14 @@ CONTAINS
     subroutine set_eta_r4_ (km, ks, ptop, pint, ak, bk)
 
 #ifdef HERMES
-      use m_realkinds, only : r8 => kind_r8  ! from mpeu
-      use m_realkinds, only : r4 => kind_r4  ! from mpeu
+      use, intrinsic :: iso_fortran_env, only : r8 => REAL64, r4 => REAL32
+
 #else
+
       subroutine set_eta_r8_(km, ks, ptop, pint, ak, bk)
       use shr_kind_mod, only : r8 => shr_kind_r8 ! from gvgcm
       use shr_kind_mod, only : r4 => shr_kind_r4 ! from gvgcm
+
 #endif
       implicit none
       integer ks, k, km


### PR DESCRIPTION
## Summary

- Sets `HERMES_LIGHT=ON` and builds only `GMAO_mpeu`, `GMAO_hermes` (light), and `GEOS_Shared` — the minimum needed by `FVdycoreCubed_GridComp`
- Extends the `HERMES_LIGHT` source list in `GMAO_hermes` to include `m_topo_remap.F90`, `m_dyn.f90`, and `m_const.f90` (needed via `use` statements in `FVdycoreCubed_GridComp`)
- Comments out the full `GMAO_Shared` build (pilgrim, transf, gfio, stoch, etc.) and `NCEP_Shared` — restore when all components are ported to MAPL3

## Context

Part of the MAPL3 flip work tracked in GEOS-ESM/GEOSgcm_GridComp#1359. Only components already ported to MAPL3 are compiled on `release/MAPL-v3`.