### PR TITLE
Migrate OVP.F90 packed-time calls to MAPL_PackedTimeMod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Migrate `OVP.F90`: replace `MAPL_PackTime` calls with `MAPL_PackedTimeCreate` from `MAPL_PackedTimeMod`
 - Migrate `GEOS_TopoGet.F90` from bare `use MAPL2` to `use MAPL` + `use MAPL2, only:` for remaining MAPL2-only symbols
 - Migrate `GEOS_TopoGet.F90` from BinIO (`GETFILE`/`FREE_FILE`) to NetCDF4 via `Netcdf4_Fileformatter`; binary/ASCII topo files are no longer supported
 

--- a/GEOS_Shared/OVP.F90
+++ b/GEOS_Shared/OVP.F90
@@ -14,7 +14,7 @@ module OVP
 
   use ESMF
   use MAPL
-  use MAPL2, only: MAPL_PackTime
+  use MAPL_PackedTimeMod, only: MAPL_PackedTimeCreate => PackedTimeCreate
   use mapl3g_GridGet, only: GridGetCoordinates
   
   implicit none
@@ -225,7 +225,7 @@ contains
        iM = VAL/60
        iS = VAL - iM*60
 !      PRINT "(I2,'h ',I2,'m ',I2,'s  ')",iH,iM,iS
-       CALL MAPL_PackTime(VAL,iH,iM,iS)
+       VAL = MAPL_PackedTimeCreate(iH,iM,iS)
        MASK(I,J) = VAL
      ENDDO
      ENDDO
@@ -303,7 +303,7 @@ contains
      IHR = IHR - EXTRA_DAYS*24
 
    ! Pack the new time
-     call MAPL_PackTime(ans,IHR,IMN,ISC)
+     ans = MAPL_PackedTimeCreate(IHR,IMN,ISC)
 
      OVP_end_of_timestep_hms = ans
 


### PR DESCRIPTION
## Summary
- `GEOS_Shared/OVP.F90`: replace two `MAPL_PackTime` calls with `MAPL_PackedTimeCreate` from `MAPL_PackedTimeMod`

Part of GEOS-ESM/MAPL#4811 — enables deletion of legacy packed-time symbols from `Base_Base`.