### PR TITLE
Migrate MAPL2/MAPL_BaseMod to source modules in GEOS_Shared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Migrate `GEOS_Shared/windfix.F90` from `use MAPL2, only: MAPL_GridGet` to `use mapl_MaplGrid, only: MAPL_GridGet` (MAPL#4857)
 - Migrate `OVP.F90`: replace `MAPL_PackTime` calls with `MAPL_PackedTimeCreate` from `MAPL_PackedTimeMod`
 - Migrate `GEOS_TopoGet.F90` from bare `use MAPL2` to `use MAPL` + `use MAPL2, only:` for remaining MAPL2-only symbols
 - Migrate `GEOS_TopoGet.F90` from BinIO (`GETFILE`/`FREE_FILE`) to NetCDF4 via `Netcdf4_Fileformatter`; binary/ASCII topo files are no longer supported

--- a/GEOS_Shared/windfix.F90
+++ b/GEOS_Shared/windfix.F90
@@ -7,7 +7,7 @@
 
       use ESMF
       use MAPL, MAPL_GridGet_UNUSED => MAPL_GridGet
-      use MAPL2, only: MAPL_GridGet
+      use mapl_MaplGrid, only: MAPL_GridGet
 
       implicit none
 


### PR DESCRIPTION
## Summary

Migrates `windfix.F90` away from `use MAPL2` for `MAPL_GridGet`, as `MAPL_GridGet` is being removed from `MAPL2` in GEOS-ESM/MAPL#4857.

## Changes

- `GEOS_Shared/windfix.F90`: `use MAPL2, only: MAPL_GridGet` → `use mapl_MaplGrid, only: MAPL_GridGet`

Closes #428
Part of GEOS-ESM/MAPL#4857