### PR TITLE
Migrate windfix.F90 off mapl_MaplGrid to use MAPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Migrate `GEOS_Shared/windfix.F90` from `use mapl_MaplGrid` to `use MAPL` for `mapl_GridGetGlobalCellCountPerDim`; `DIMS` made allocatable (MAPL#4875)
 - Migrate `GEOS_Shared/windfix.F90` from `use MAPL2, only: MAPL_GridGet` to `use mapl_MaplGrid, only: MAPL_GridGet` (MAPL#4857)
 - Migrate `OVP.F90`: replace `MAPL_PackTime` calls with `MAPL_PackedTimeCreate` from `MAPL_PackedTimeMod`
 - Migrate `GEOS_TopoGet.F90` from bare `use MAPL2` to `use MAPL` + `use MAPL2, only:` for remaining MAPL2-only symbols

--- a/GEOS_Shared/windfix.F90
+++ b/GEOS_Shared/windfix.F90
@@ -6,7 +6,7 @@
                            vintdiva,vintdivb,vintdivc )
 
       use ESMF
-      use MAPL, only: mapl_GridGetGlobalCellCountPerDim
+      use MAPL
 
       implicit none
 

--- a/GEOS_Shared/windfix.F90
+++ b/GEOS_Shared/windfix.F90
@@ -6,14 +6,13 @@
                            vintdiva,vintdivb,vintdivc )
 
       use ESMF
-      use MAPL, MAPL_GridGet_UNUSED => MAPL_GridGet
-      use mapl_MaplGrid, only: MAPL_GridGet
+      use MAPL, only: mapl_GridGetGlobalCellCountPerDim
 
       implicit none
 
       type (ESMF_VM)   :: VM
       type (ESMF_Grid) :: GRIDana
-      integer          :: DIMS(ESMF_MAXGRIDDIM)
+      integer, allocatable :: DIMS(:)
       integer          :: RC,STATUS
 
       character(len=ESMF_MAXSTR) :: IAm
@@ -67,7 +66,7 @@
       call ESMF_VmGet (VM, mpicommunicator=comm, rc=status)
       VERIFY_(STATUS)
 
-      call  MAPL_GridGet(GRIDana, globalCellCountPerDim=DIMS, RC=STATUS)
+      call mapl_GridGetGlobalCellCountPerDim(GRIDana, globalCellCountPerDim=DIMS, RC=STATUS)
       img = DIMS(1) ! global grid dim
       jmg = DIMS(2) ! global grid dim
       imjmg = img*jmg


### PR DESCRIPTION
## Summary

Closes #431

Depends on GEOS-ESM/MAPL#4877.

- Replace `use MAPL_MaplGrid, only: MAPL_GridGet` with `use MAPL, only: mapl_GridGetGlobalCellCountPerDim`
- Remove the `MAPL_GridGet_UNUSED` workaround which was needed to avoid the name clash with `mapl_MaplGrid`
- Make `DIMS` allocatable to match the MAPL3 interface