### PR TITLE
Migrate GEOS_TopoGet.F90 from use MAPL2 to use MAPL (fixes #433)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrate `GEOS_Shared/windfix.F90` from `use mapl_MaplGrid` to `use MAPL` for `mapl_GridGetGlobalCellCountPerDim`; `DIMS` made allocatable (MAPL#4875)
 - Migrate `GEOS_Shared/windfix.F90` from `use MAPL2, only: MAPL_GridGet` to `use mapl_MaplGrid, only: MAPL_GridGet` (MAPL#4857)
 - Migrate `OVP.F90`: replace `MAPL_PackTime` calls with `MAPL_PackedTimeCreate` from `MAPL_PackedTimeMod`
+- Migrate `GEOS_TopoGet.F90` from `use MAPL2` to `use MAPL` now that `MAPL_VarRead` and related symbols are re-exported through the `MAPL` umbrella (MAPL#4882)
 - Migrate `GEOS_TopoGet.F90` from bare `use MAPL2` to `use MAPL` + `use MAPL2, only:` for remaining MAPL2-only symbols
 - Migrate `GEOS_TopoGet.F90` from BinIO (`GETFILE`/`FREE_FILE`) to NetCDF4 via `Netcdf4_Fileformatter`; binary/ASCII topo files are no longer supported
 

--- a/GEOS_Shared/GEOS_TopoGet.F90
+++ b/GEOS_Shared/GEOS_TopoGet.F90
@@ -13,7 +13,6 @@ module GEOS_TopoGetMod
 
   use ESMF
   use MAPL
-  use MAPL2, only: MAPL_VarRead  ! TODO: move NCIOMod to mapl_base3g so this comes from MAPL
   
   implicit none
   private


### PR DESCRIPTION
## Summary

- Replaces `use MAPL2` with `use MAPL` in `GEOS_Shared/GEOS_TopoGet.F90`
- No logic changes — use statement migration only

## Dependency

Requires GEOS-ESM/MAPL#4882 (merged) which re-exports `MAPL_VarRead` and related symbols through the `MAPL` umbrella module.