### PR TITLE
Replace MAPL2 dependency with MAPL in GEOS_Shared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Remove `MAPL2` from `GEOS_Shared` CMake dependencies; replace with `MAPL` (#435)
 - Migrate `GEOS_Shared/windfix.F90` from `use mapl_MaplGrid` to `use MAPL` for `mapl_GridGetGlobalCellCountPerDim`; `DIMS` made allocatable (MAPL#4875)
 - Migrate `GEOS_Shared/windfix.F90` from `use MAPL2, only: MAPL_GridGet` to `use mapl_MaplGrid, only: MAPL_GridGet` (MAPL#4857)
 - Migrate `OVP.F90`: replace `MAPL_PackTime` calls with `MAPL_PackedTimeCreate` from `MAPL_PackedTimeMod`

--- a/GEOS_Shared/CMakeLists.txt
+++ b/GEOS_Shared/CMakeLists.txt
@@ -8,7 +8,7 @@ set (srcs
   getco2.F90 atmOceanIntLayer.F90
   )
 
-esma_add_library(${this} SRCS ${srcs} DEPENDENCIES MAPL2 MAPL MAPL.geom ESMF::ESMF NetCDF::NetCDF_Fortran)
+esma_add_library(${this} SRCS ${srcs} DEPENDENCIES MAPL MAPL.geom ESMF::ESMF NetCDF::NetCDF_Fortran)
 
 # special cases
 set_source_files_properties(sphere.F PROPERTIES COMPILE_FLAGS "${FREAL8}")


### PR DESCRIPTION
## Summary

- Removes `MAPL2` from `DEPENDENCIES` in `GEOS_Shared/CMakeLists.txt`, replacing with `MAPL`

## Motivation

Part of the MAPL2 retirement sequence. Contingent on GEOS-ESM/MAPL#4889 (PR1) being merged.

## Related Issues

Closes #435