### PR TITLE
Replace use mapl3g_GridGet with use MAPL in OVP.F90

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Replace `use mapl3g_GridGet` with `use MAPL` in `GEOS_Shared/OVP.F90`;
+  `MAPL_GridGetCoordinates` is now accessed through the MAPL umbrella module
+  following the Phase 9 `mapl3g_` → `mapl_` rename in MAPL (#437)
 - Remove `MAPL2` from `GEOS_Shared` CMake dependencies; replace with `MAPL` (#435)
 - Migrate `GEOS_Shared/windfix.F90` from `use mapl_MaplGrid` to `use MAPL` for `mapl_GridGetGlobalCellCountPerDim`; `DIMS` made allocatable (MAPL#4875)
 - Migrate `GEOS_Shared/windfix.F90` from `use MAPL2, only: MAPL_GridGet` to `use mapl_MaplGrid, only: MAPL_GridGet` (MAPL#4857)

--- a/GEOS_Shared/OVP.F90
+++ b/GEOS_Shared/OVP.F90
@@ -15,7 +15,6 @@ module OVP
   use ESMF
   use MAPL
   use MAPL_PackedTimeMod, only: MAPL_PackedTimeCreate => PackedTimeCreate
-  use mapl3g_GridGet, only: GridGetCoordinates
   
   implicit none
   private
@@ -117,7 +116,7 @@ contains
 
     call MAPL_GridCompGet(GC, grid=grid, _RC)
 
-    call GridGetCoordinates(grid, LONS, lats, _RC)        !  Get LONS
+    call mapl_GridGetCoordinates(grid, LONS, lats, _RC)        !  Get LONS
 
     call ESMF_GridCompGet ( GC, CONFIG=CF, __RC__ )                   !  Get Config
 


### PR DESCRIPTION
## Summary

- Replace `use mapl3g_GridGet` with `use MAPL` in `GEOS_Shared/OVP.F90`; `MAPL_GridGetCoordinates` is re-exported by the MAPL umbrella module
- Update CHANGELOG

## Motivation

MAPL Phase 9 (#4944) renamed all `mapl3g_` module prefixes to `mapl_`. This PR updates `OVP.F90` to use the standard `use MAPL` umbrella rather than the now-renamed internal module.