### PR TITLE
Update CHANGELOG for v3.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [3.0.0] - 2026-05-27
+
+### Added
+
+- Added new `compute_radar_reflectivity.F90` module in `GEOS_Shared` for computing radar reflectivity
+- Added L186 extended model top levels in `m_set_eta.F90`
+- Added 41 ML levels for PYMLINC in `m_set_eta.F90`
+
+### Changed
+
+- Updated `iliqskin` logic to apply only to snow or snow & graupel (as in SFE25/SFE26)
+- Merged latest v12-SFE26 code for L72 (zero-diff)
+- Renamed `GMAO_gfio` source files from `.f`/`.f90` to `.F`/`.F90` for preprocessor compatibility
+- Renamed `GMAO_hermes` source files from `.f90` to `.F90` for preprocessor compatibility
+- Updated `m_random.F` in `GMAO_mpeu`
+- Updated CI configuration (CircleCI and GitHub Actions/Spack)
+
+### Fixed
+
+- Fixed bug in `calcdbz` when `ivarint==0`
+- Added additional bounds protections on QSAT tables (`qsat_fast.code`, `qsat_new.code`, `qsatice.code`, `qsatlqu.code`)
+- Fixes for Flang 22 compiler compatibility
+- Fixes for Open MPI 5 compatibility
+- Updates for Intel `ifx` builds
+
 ## [2.1.7] - 2026-04-15
 
 ### Added


### PR DESCRIPTION
## Summary

This PR adds the `[3.0.0]` entry to `CHANGELOG.md` in preparation for the v3.0.0 release.

### Changes since v2.1.7

**Added**
- New `compute_radar_reflectivity.F90` module in `GEOS_Shared`
- L186 extended model top levels in `m_set_eta.F90`
- 41 ML levels for PYMLINC in `m_set_eta.F90`

**Changed**
- Updated `iliqskin` logic (snow/graupel, SFE25/SFE26)
- Merged latest v12-SFE26 code for L72 (zero-diff)
- Renamed `GMAO_gfio` and `GMAO_hermes` source files to `.F`/`.F90` for preprocessor compatibility
- Updated `m_random.F` in `GMAO_mpeu`
- Updated CI configuration (CircleCI and GitHub Actions/Spack)

**Fixed**
- Bug in `calcdbz` when `ivarint==0`
- Additional bounds protections on QSAT tables
- Flang 22 compiler compatibility
- Open MPI 5 compatibility
- Intel `ifx` build fixes