### PR TITLE
Fix for ods cmake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix for ods cmake
+
 ### Removed
 
 ### Deprecated

--- a/GMAO_ods/CMakeLists.txt
+++ b/GMAO_ods/CMakeLists.txt
@@ -114,8 +114,8 @@ separate_arguments(ODSMETA_ARGS NATIVE_COMMAND "sed -e 's/integer, parameter//g'
 add_custom_command (
    OUTPUT odsmeta.py
    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-   SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/odsmeta.h
    COMMAND grep 'integer, parameter' ${CMAKE_CURRENT_SOURCE_DIR}/odsmeta.h | ${ODSMETA_ARGS} | grep -v idsats > odsmeta.py
+   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/odsmeta.h
    )
 
 add_custom_target(make_odsmeta ALL DEPENDS odsmeta.py)


### PR DESCRIPTION
This PR fixes a small CMake issue in GMAO_ods. The old code threw a warning and this is the better way to do it.